### PR TITLE
Add K2 Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,8 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.9.22"
+    kotlin("jvm") version "2.0.0"
 }
 
 buildscript {
@@ -26,8 +27,8 @@ subprojects {
         maven(url = "https://oss.sonatype.org/content/repositories/snapshots/")
     }
     tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = libs.versions.jvmTarget.get()
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_11
         }
     }
 

--- a/create-plugin/build.gradle.kts
+++ b/create-plugin/build.gradle.kts
@@ -11,11 +11,10 @@ plugins {
 dependencies {
     compileOnly(libs.kotlinCompiler)
 
-    implementation(libs.arrowMeta)
     implementation(libs.bundles.jackson)
     implementation(libs.kotlinReflect)
 
-    testImplementation(libs.arrowTest)
+    testImplementation(libs.classGraph)
     testImplementation(libs.compilerTest)
     testImplementation(libs.bundles.ktor)
     testImplementation(libs.assertJ)

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/DeclarationExtension.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/DeclarationExtension.kt
@@ -1,0 +1,35 @@
+package io.github.tabilzad.ktor
+
+import org.jetbrains.kotlin.container.StorageComponentContainer
+import org.jetbrains.kotlin.container.useInstance
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.extensions.StorageComponentContainerContributor
+import org.jetbrains.kotlin.platform.TargetPlatform
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.resolve.checkers.DeclarationChecker
+import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
+
+// Registers K1 component
+class DeclarationExtension(
+    private val configuration: PluginConfiguration
+) : StorageComponentContainerContributor {
+
+
+    override fun registerModuleComponents(
+        container: StorageComponentContainer,
+        platform: TargetPlatform,
+        moduleDescriptor: ModuleDescriptor
+    ) {
+
+        container.useInstance(object : DeclarationChecker {
+            override fun check(
+                declaration: KtDeclaration,
+                descriptor: DeclarationDescriptor,
+                context: DeclarationCheckerContext
+            ) {
+                swaggerExtensionPhase(configuration, declaration, descriptor, context)
+            }
+        })
+    }
+}

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/FileUtils.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/FileUtils.kt
@@ -24,8 +24,10 @@ fun locateOrCreateSwaggerFile(
         val mainModule = "$modulePath/src/main"
         val resourcesDir = File(mainModule).listFiles()?.find {
             (listOf("res", "resources").contains(it.name))
-        } ?: throw IllegalAccessException("Couldn't find resources directory to save openapi file to." +
-                " Searched in $modulePath")
+        } ?: throw IllegalAccessException(
+            "Couldn't find resources directory to save openapi file to." +
+                    " Searched in $modulePath"
+        )
 
         File("${resourcesDir.absolutePath}/openapi/").apply {
             mkdir()
@@ -48,6 +50,9 @@ fun OpenApiSpec.serializeAndWriteTo(configuration: PluginConfiguration) {
         val sorted = new.copy(
             components = new.components.copy(
                 schemas = new.components.schemas.toSortedMap()
+                    .mapValues {
+                        it.value.copy(properties = it.value.properties?.toSortedMap())
+                    }
             )
         )
         file.writeText(mapper.writeValueAsString(sorted))

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/KtorDocsCommandLineProcessor.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/KtorDocsCommandLineProcessor.kt
@@ -1,6 +1,7 @@
 package io.github.tabilzad.ktor
 
 import io.github.tabilzad.ktor.SwaggerConfigurationKeys.ARG_BUILD_PATH
+import io.github.tabilzad.ktor.SwaggerConfigurationKeys.ARG_DERIVE_PROP_REQ
 import io.github.tabilzad.ktor.SwaggerConfigurationKeys.ARG_DESCR
 import io.github.tabilzad.ktor.SwaggerConfigurationKeys.ARG_ENABLED
 import io.github.tabilzad.ktor.SwaggerConfigurationKeys.ARG_FORMAT
@@ -13,6 +14,7 @@ import io.github.tabilzad.ktor.SwaggerConfigurationKeys.ARG_SAVE_IN_BUILD
 import io.github.tabilzad.ktor.SwaggerConfigurationKeys.ARG_TITLE
 import io.github.tabilzad.ktor.SwaggerConfigurationKeys.ARG_VER
 import io.github.tabilzad.ktor.SwaggerConfigurationKeys.OPTION_BUILD_PATH
+import io.github.tabilzad.ktor.SwaggerConfigurationKeys.OPTION_DERIVE_PROP_REQ
 import io.github.tabilzad.ktor.SwaggerConfigurationKeys.OPTION_DESCR
 import io.github.tabilzad.ktor.SwaggerConfigurationKeys.OPTION_FORMAT
 import io.github.tabilzad.ktor.SwaggerConfigurationKeys.OPTION_HIDE_PRIVATE
@@ -44,6 +46,7 @@ object SwaggerConfigurationKeys {
     const val OPTION_REQUEST_BODY = "generateRequestSchemas"
     const val OPTION_HIDE_TRANSIENT = "hideTransientFields"
     const val OPTION_HIDE_PRIVATE = "hidePrivateAndInternalFields"
+    const val OPTION_DERIVE_PROP_REQ = "deriveFieldRequirementFromTypeNullability"
     const val OPTION_FORMAT = "format"
 
     val ARG_ENABLED = CompilerConfigurationKey.create<Boolean>(OPTION_IS_ENABLED)
@@ -57,6 +60,7 @@ object SwaggerConfigurationKeys {
     val ARG_REQUEST_FEATURE = CompilerConfigurationKey.create<Boolean>(OPTION_REQUEST_BODY)
     val ARG_HIDE_TRANSIENTS = CompilerConfigurationKey.create<Boolean>(OPTION_HIDE_TRANSIENT)
     val ARG_HIDE_PRIVATE = CompilerConfigurationKey.create<Boolean>(OPTION_HIDE_PRIVATE)
+    val ARG_DERIVE_PROP_REQ = CompilerConfigurationKey.create<Boolean>(OPTION_DERIVE_PROP_REQ)
     val ARG_FORMAT = CompilerConfigurationKey.create<String>(OPTION_FORMAT)
 }
 
@@ -132,6 +136,12 @@ class KtorDocsCommandLineProcessor : CommandLineProcessor {
             "Hide private or internal fields in body definitions",
             false
         )
+        val derivePropRequirement = CliOption(
+            OPTION_DERIVE_PROP_REQ,
+            "true sets automation resolution, false sets to explicit",
+            "Automatically derive object properties' requirement from the type nullability",
+            false
+        )
         val formatOption = CliOption(
             OPTION_FORMAT,
             "Specification format",
@@ -156,6 +166,7 @@ class KtorDocsCommandLineProcessor : CommandLineProcessor {
             requestSchema,
             hideTransientFields,
             hidePrivateAndInternalFields,
+            derivePropRequirement,
             formatOption
         )
 
@@ -183,6 +194,8 @@ class KtorDocsCommandLineProcessor : CommandLineProcessor {
             pathOption -> configuration.put(ARG_PATH, value)
 
             formatOption -> configuration.put(ARG_FORMAT, value)
+
+            derivePropRequirement -> configuration.put(ARG_DERIVE_PROP_REQ, value.toBooleanStrictOrNull() ?: true)
 
             requestSchema -> configuration.put(ARG_REQUEST_FEATURE, value.toBooleanStrictOrNull() ?: true)
 

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/KtorMetaPluginRegistrar.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/KtorMetaPluginRegistrar.kt
@@ -1,17 +1,54 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
 package io.github.tabilzad.ktor
 
-import arrow.meta.CliPlugin
-import arrow.meta.Meta
-import arrow.meta.invoke
-import arrow.meta.phases.CompilerContext
+import io.github.tabilzad.ktor.k2.SwaggerDeclarationChecker
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.extensions.StorageComponentContainerContributor
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
+import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension.Factory
+import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
+import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 
-open class KtorMetaPluginRegistrar : Meta() {
-    override fun intercept(ctx: CompilerContext): List<CliPlugin> = listOf(ktorDocs)
+
+open class KtorMetaPluginRegistrar : CompilerPluginRegistrar() {
+    override val supportsK2: Boolean
+        get() = true
+
+    @OptIn(ExperimentalCompilerApi::class)
+    override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
+        configuration.put(JVMConfigurationKeys.IR, true)
+        val config = configuration.buildPluginConfiguration()
+        // K1
+        StorageComponentContainerContributor.registerExtension(DeclarationExtension(config))
+        // K2
+        FirExtensionRegistrarAdapter.registerExtension(SwaggerCheckers(configuration))
+    }
 }
 
-val Meta.ktorDocs: CliPlugin
-    get() = "ktorDocs" {
-        val config = configuration.buildPluginConfiguration()
-        meta(swaggerExtensionPhase(config), enableIr())
+
+class FirCheckers(session: FirSession, configuration: CompilerConfiguration) : FirAdditionalCheckersExtension(session) {
+    override val declarationCheckers: DeclarationCheckers = object : DeclarationCheckers() {
+        override val simpleFunctionCheckers: Set<FirSimpleFunctionChecker> =
+            setOf(SwaggerDeclarationChecker(session, configuration))
     }
+
+    companion object {
+        fun getFactory(configuration: CompilerConfiguration): Factory {
+            return Factory { session -> FirCheckers(session, configuration) }
+        }
+    }
+}
+
+class SwaggerCheckers(private val configuration: CompilerConfiguration) : FirExtensionRegistrar() {
+    override fun ExtensionRegistrarContext.configurePlugin() {
+        +FirCheckers.getFactory(configuration)
+    }
+}
 

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/annotations/Annotations.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/annotations/Annotations.kt
@@ -1,0 +1,50 @@
+package io.github.tabilzad.ktor.annotations
+
+import kotlin.reflect.KClass
+
+@Deprecated("Please use @GenerateOpenApi")
+typealias KtorDocs = GenerateOpenApi
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.EXPRESSION)
+annotation class GenerateOpenApi
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.EXPRESSION)
+annotation class IgnoreOpenApi
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.EXPRESSION)
+annotation class Tag(val tags: Array<String> = [])
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.EXPRESSION)
+annotation class KtorResponds(
+    val mapping: Array<ResponseEntry>
+)
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.EXPRESSION)
+annotation class ResponseEntry(
+    val status: String,
+    val type: KClass<*>,
+    val isCollection: Boolean = false,
+    val description: String = ""
+)
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FUNCTION,
+    AnnotationTarget.EXPRESSION)
+annotation class KtorDescription(
+    val summary: String = "",
+    val description: String = "",
+    val required: Boolean = false,
+    val tags: Array<String> = [])
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD, AnnotationTarget.CLASS)
+annotation class KtorFieldDescription(
+    val summary: String = "",
+    val description: String = "",
+    val required: Boolean = false,
+    val tags: Array<String> = [])

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ClassDescriptorVisitorK2.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ClassDescriptorVisitorK2.kt
@@ -1,0 +1,361 @@
+package io.github.tabilzad.ktor.k2
+
+import io.github.tabilzad.ktor.OpenApiSpec
+import io.github.tabilzad.ktor.OpenApiSpec.ObjectType
+import io.github.tabilzad.ktor.PluginConfiguration
+import io.github.tabilzad.ktor.annotations.KtorDescription
+import io.github.tabilzad.ktor.annotations.KtorFieldDescription
+import io.github.tabilzad.ktor.names
+import io.github.tabilzad.ktor.visitors.KtorDescriptionBag
+import io.github.tabilzad.ktor.visitors.toSwaggerType
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.declarations.*
+import org.jetbrains.kotlin.fir.declarations.utils.isEnumClass
+import org.jetbrains.kotlin.fir.declarations.utils.isSealed
+import org.jetbrains.kotlin.fir.expressions.FirExpressionEvaluator
+import org.jetbrains.kotlin.fir.resolve.defaultType
+import org.jetbrains.kotlin.fir.resolve.toClassSymbol
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.types.*
+import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitor
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.util.PrivateForInline
+import org.jetbrains.kotlin.util.getValueOrNull
+
+data class GenericParameter(
+    val genericName: String, val genericTypeRef: ConeKotlinType?
+)
+
+internal class ClassDescriptorVisitorK2(
+    private val config: PluginConfiguration,
+    private val session: FirSession,
+    private val context: CheckerContext,
+    private val genericParameters: List<GenericParameter> = emptyList(),
+    val classNames: MutableList<ObjectType> = mutableListOf(),
+) : FirDefaultVisitor<ObjectType, ObjectType>() {
+
+
+    @OptIn(SealedClassInheritorsProviderInternals::class, SymbolInternals::class)
+    override fun visitProperty(property: FirProperty, data: ObjectType): ObjectType {
+
+        val coneTypeOrNull = property.returnTypeRef.coneTypeOrNull!!
+        val type = if (coneTypeOrNull is ConeTypeParameterType && genericParameters.isNotEmpty()) {
+            genericParameters.find { it.genericName == coneTypeOrNull.renderReadable() }?.genericTypeRef!!
+        } else {
+            coneTypeOrNull
+        }
+        val typeSymbol = type.toRegularClassSymbol(session)
+
+        val result = when {
+            type.isPrimitiveOrNullablePrimitive || type.isString || type.isNullableString -> {
+                if (data.type == "object") {
+                    data.addProperty(
+                        property,
+                        objectType = ObjectType(
+                            type = type.className()?.toSwaggerType() ?: "Unknown",
+                        ), session
+                    )
+                }
+                if (data.type == "array") {
+
+                    val thisPrimitiveObj = ObjectType(
+                        type.toString().toSwaggerType(),
+                    )
+                    data.items = thisPrimitiveObj
+                }
+                data
+            }
+
+            else -> {
+                val fqClassName = type.fqNameStr()
+
+                when {
+                    type.isMap() -> {
+
+                        val valueType = type.typeArguments.last()
+
+                        fun ConeTypeProjection.createMapDefinition(): ObjectType? {
+                            return this.type?.let { valueClassType ->
+                                val typeSymbol = valueClassType.toRegularClassSymbol(session)
+                                val acc = ObjectType("object", mutableMapOf())
+
+                                when {
+                                    valueClassType.isPrimitiveOrNullablePrimitive || valueClassType.isString || valueClassType.isNullableString -> {
+                                        acc.additionalProperties =
+                                            ObjectType(valueClassType.className()?.toSwaggerType())
+                                    }
+
+                                    valueClassType.isIterable() -> {
+                                        acc.type = "object"
+                                        acc.additionalProperties = valueClassType.toNestedSwagger()
+                                    }
+
+                                    valueClassType.isEnum || typeSymbol?.isEnumClass == true -> {
+                                        acc.type = "object"
+                                        acc.additionalProperties = ObjectType(
+                                            "string", enum = typeSymbol?.resolveEnumEntries()
+                                        )
+                                    }
+
+                                    valueClassType.isAny -> {
+                                        acc.type = "object"
+                                    }
+
+                                    else -> {
+                                        val gName = valueClassType.fqNameStr()
+                                        if (!classNames.names.contains(gName)) {
+                                            val q = ObjectType(
+                                                "object",
+                                                null,
+                                                fqName = gName,
+                                                //description = docsDescription
+                                            )
+                                            classNames.add(q)
+
+                                            valueClassType.getMembers(session, config).forEach { it ->
+                                                it.accept(this@ClassDescriptorVisitorK2, q)
+                                            }
+                                        }
+
+                                        acc.additionalProperties = ObjectType(
+                                            type = null, ref = "#/components/schemas/${gName}"
+                                        )
+                                    }
+                                }
+
+                                acc
+                            }
+                        }
+
+                        val item = valueType.createMapDefinition()
+                        data.addProperty(property, item, session)
+                        data
+                    }
+
+                    type.isIterable() -> {
+                        data.addProperty(property, type.toNestedSwagger(), session)
+                        data
+                    }
+
+                    type.isEnum || typeSymbol?.isEnumClass == true -> {
+
+                        val enumValues = typeSymbol?.resolveEnumEntries()
+                        data.addProperty(
+                            property, ObjectType(
+                                type = "string",
+                                enum = enumValues,
+                                //description = docsDescription
+                            ),
+                            session
+                        )
+                        data
+                    }
+
+                    typeSymbol?.isSealed == true -> {
+
+                        if (!classNames.names.contains(fqClassName)) {
+                            val inheritorClassIds = typeSymbol.fir.sealedInheritorsAttr?.getValueOrNull()
+                            val internal = ObjectType("object",
+                                fqName = fqClassName,
+                                oneOf = inheritorClassIds?.map { OpenApiSpec.SchemaRef("#/components/schemas/${it.asFqNameString()}") })
+                            classNames.add(internal)
+                            type.getMembers(session, config).forEach { nestedDescr ->
+                                nestedDescr.accept(this, internal)
+                            }
+
+                            inheritorClassIds?.forEach { it: ClassId ->
+
+                                val inheritorType = ObjectType(
+                                    "object",
+                                    fqName = it.asFqNameString(),
+                                )
+                                classNames.add(inheritorType)
+                                val fir: FirClass? = it.toLookupTag().toClassSymbol(session)?.fir
+                                fir?.accept(this, inheritorType)
+                            }
+                        }
+
+                        data.addProperty(
+                            property, ObjectType(
+                                type = null,
+                                fqName = fqClassName,
+                                //description = docsDescription,
+                                ref = "#/components/schemas/${fqClassName}"
+                            ), session
+                        )
+
+                        data
+                    }
+
+                    type.isAny -> {
+                        data
+                    }
+
+                    else -> {
+
+
+                        if (!classNames.names.contains(fqClassName)) {
+                            val internal = ObjectType(
+                                "object",
+                                fqName = fqClassName
+                            )
+                            classNames.add(internal)
+
+                            if (type.typeArguments.isEmpty()) {
+                                type.getMembers(session, config).forEach { nestedDescr ->
+                                    nestedDescr.accept(this, internal)
+                                }
+                            } else {
+                                val things = type.getMembers(session, config)
+                                    .map { nestedDescr ->
+                                        nestedDescr.accept(
+                                            ClassDescriptorVisitorK2(config, session, context,
+                                                classNames = classNames,
+                                                genericParameters = type.typeArguments.zip(
+                                                    typeSymbol?.typeParameterSymbols ?: emptyList()
+                                                ).map { (specifiedType, genericType) ->
+                                                    GenericParameter(
+                                                        genericTypeRef = specifiedType.type,
+                                                        genericName = genericType.name.asString()
+                                                    )
+                                                }), internal
+                                        )
+                                    }
+
+                                println()
+                            }
+                        }
+
+                        data.addProperty(
+                            property, ObjectType(
+                                type = null,
+                                fqName = fqClassName,
+                                //description = docsDescription,
+                                ref = "#/components/schemas/${fqClassName}"
+                            ), session
+                        )
+
+                        data
+                    }
+                }
+            }
+        }
+
+
+        return result
+    }
+
+    override fun visitClass(klass: FirClass, data: ObjectType): ObjectType {
+        klass.defaultType().getMembers(session, config).forEach { it.accept(this, data) }
+        return data
+    }
+
+    override fun visitElement(element: FirElement, data: ObjectType): ObjectType {
+        return data
+    }
+
+    private fun ConeKotlinType.toNestedSwagger(): ObjectType {
+        val arrayItems = type.typeArguments.mapNotNull { it.type }.map {
+            convertSubTree(it)
+        }
+        return ObjectType("array", items = arrayItems.firstOrNull())// list only take a single generic type
+    }
+
+    private fun convertSubTree(type: ConeKotlinType?): ObjectType? {
+        type?.typeArguments?.mapNotNull { it.type }?.map { convertSubTree(it) }
+        return type?.resolveItems()
+    }
+
+
+    private fun ConeKotlinType.resolveItems(
+    ): ObjectType? {
+        val type = this
+        val typeSymbol = toRegularClassSymbol(session)
+        val jetTypeFqName = fqNameStr()
+        return if (type.isPrimitive || type.isString || type.isPrimitiveOrNullablePrimitive || isNullableString) {
+            ObjectType(type.className()?.toSwaggerType())
+        } else if (type.isIterable()) {
+            ObjectType("array", items = this.typeArguments.firstNotNullOfOrNull { it.type }?.resolveItems())
+        } else if (type.isEnum || typeSymbol?.isEnumClass == true) {
+            ObjectType("string").apply {
+                enum = typeSymbol?.resolveEnumEntries()
+            }
+        } else {
+            if (!classNames.names.contains(jetTypeFqName)) {
+
+                val refObject = ObjectType(
+                    "object", properties = null, fqName = jetTypeFqName
+                )
+                classNames.add(refObject)
+                type.getMembers(session, config).forEach { it: FirDeclaration ->
+                    // it.accept(this@ClassDescriptorVisitorK2, q)
+                    it.accept(
+                        ClassDescriptorVisitorK2(config, session, context,
+                            classNames = classNames,
+                            genericParameters = type.typeArguments.zip(
+                                typeSymbol?.typeParameterSymbols ?: emptyList()
+                            ).map { (specifiedType, genericType) ->
+                                GenericParameter(
+                                    genericTypeRef = specifiedType.type,
+                                    genericName = genericType.name.asString()
+                                )
+                            }), refObject
+                    )
+                }
+            }
+            ObjectType(null).apply {
+                ref = "#/components/schemas/${jetTypeFqName}"
+            }
+        }
+    }
+
+    @OptIn(PrivateForInline::class)
+    private fun FirProperty.findDocsDescription(session: FirSession): KtorDescriptionBag? {
+        val docsAnnotation =
+            findAnnotation(KtorDescription::class.simpleName) ?: findAnnotation(KtorFieldDescription::class.simpleName)
+            ?: return null
+
+        val resolved = FirExpressionEvaluator.evaluateAnnotationArguments(docsAnnotation, session)
+        val summary = resolved?.entries?.find { it.key.asString() == "summary" }?.value?.result
+        val descr = resolved?.entries?.find { it.key.asString() == "description" }?.value?.result
+        val required = resolved?.entries?.find { it.key.asString() == "required" }?.value?.result
+        return KtorDescriptionBag(
+            summary = summary?.accept(StringResolutionVisitor(), ""),
+            descr = descr?.accept(StringResolutionVisitor(), ""),
+            isRequired = required?.accept(StringResolutionVisitor(), "")?.toBooleanStrictOrNull()
+                ?: (returnTypeRef.isMarkedNullable == false)
+        )
+    }
+
+    private fun ObjectType.addProperty(fir: FirProperty, objectType: ObjectType?, session: FirSession) {
+        val resolvedDescription = fir.findDocsDescription(session)
+        val docsDescription = resolvedDescription.let { it?.summary ?: it?.descr }
+        val name = fir.findName()
+        val spec = objectType ?: ObjectType("object")
+        if (properties == null) {
+            properties = mutableMapOf(name to spec)
+        } else {
+            properties?.put(name, spec)
+        }
+
+        objectType?.description = docsDescription
+
+        val isRequiredFromExplicitDesc = resolvedDescription?.isRequired
+        if (isRequiredFromExplicitDesc != null && isRequiredFromExplicitDesc) {
+            required?.add(name) ?: run {
+                required = mutableListOf(name)
+            }
+        } else if ((isRequiredFromExplicitDesc == null && fir.returnTypeRef.isMarkedNullable == false)
+            && config.deriveFieldRequirementFromTypeNullability
+        ) {
+            required?.add(name) ?: run {
+                required = mutableListOf(name)
+            }
+        }
+    }
+
+    private fun FirProperty.findName(): String = name.asString()
+}
+

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ClassIds.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ClassIds.kt
@@ -1,0 +1,22 @@
+package io.github.tabilzad.ktor.k2
+
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+
+object ClassIds {
+
+    val KTOR_APPLICATION = ClassId(FqName("io.ktor.server.application"), FqName("Application"), false)
+    val KTOR_ROUTING = ClassId(FqName("io.ktor.server.routing"), FqName("Routing"), false)
+    val KTOR_ROUTE = ClassId(FqName("io.ktor.server.routing"), FqName("Route"), false)
+    val KTOR_RECEIVE = FqName("io.ktor.server.request.receive")
+    val KTOR_QUERY_PARAM = FqName("io.ktor.server.request.ApplicationRequest.queryParameters")
+    val KTOR_RAW_QUERY_PARAM = FqName("io.ktor.server.request.ApplicationRequest.rawQueryParameters")
+
+    val KTOR_TAGS_ANNOTATION = ClassId(FqName("io.github.tabilzad.ktor"), FqName("Tag"), false)
+    val KTOR_GENERATE_ANNOTATION = ClassId(FqName("io.github.tabilzad.ktor"), FqName("GenerateOpenApi"), false)
+    val KTOR_DOCS_ANNOTATION = ClassId(FqName("io.github.tabilzad.ktor"), FqName("KtorDocs"), false)
+
+    val KTOR_DSL_ANNOTATION = ClassId(FqName("io.ktor.util"), FqName("KtorDsl"), false)
+    val TRANSIENT_ANNOTATION = ClassId(FqName("kotlin.jvm"), FqName("Transient"), false)
+
+}

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
@@ -1,0 +1,367 @@
+package io.github.tabilzad.ktor.k2
+
+import io.github.tabilzad.ktor.*
+import io.github.tabilzad.ktor.annotations.KtorDescription
+import io.github.tabilzad.ktor.annotations.KtorResponds
+import io.github.tabilzad.ktor.visitors.KtorDescriptionBag
+import io.github.tabilzad.ktor.visitors.toSwaggerType
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.declarations.*
+import org.jetbrains.kotlin.fir.declarations.utils.classId
+import org.jetbrains.kotlin.fir.expressions.*
+import org.jetbrains.kotlin.fir.references.resolved
+import org.jetbrains.kotlin.fir.references.toResolvedFunctionSymbol
+import org.jetbrains.kotlin.fir.resolve.firClassLike
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.types.*
+import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitor
+import org.jetbrains.kotlin.ir.util.IrMessageLogger
+import org.jetbrains.kotlin.util.PrivateForInline
+
+internal class ExpressionsVisitorK2(
+    private val config: PluginConfiguration,
+    private val context: CheckerContext,
+    private val session: FirSession,
+    private val log: IrMessageLogger
+) : FirDefaultVisitor<List<KtorElement>, KtorElement?>() {
+
+    init {
+        println("BeginK2 Visitor")
+    }
+
+    val classNames = mutableListOf<OpenApiSpec.ObjectType>()
+
+    override fun visitElement(expression: FirElement, parent: KtorElement?): List<KtorElement> {
+        return parent.wrapAsList()
+    }
+
+    @OptIn(PrivateForInline::class)
+    private fun FirFunction.findTags(session: FirSession): Set<String>? {
+        val annotation = findAnnotation(ClassIds.KTOR_TAGS_ANNOTATION, session) ?: return null
+        val resolved = FirExpressionEvaluator.evaluateAnnotationArguments(annotation, session)
+        return resolved?.entries?.find { it.key.asString() == "tags" }?.value?.result?.accept(
+            StringArrayLiteralVisitor(),
+            emptyList()
+        )?.toSet()
+    }
+
+    // Evaluation Order 1
+    override fun visitSimpleFunction(simpleFunction: FirSimpleFunction, parent: KtorElement?): List<KtorElement> {
+
+        val extractedTags = simpleFunction.findTags(session)
+        val c = parent ?: DocRoute("/", tags = extractedTags)
+
+        simpleFunction.acceptChildren(this, c)
+        return c.wrapAsList()
+    }
+
+
+    // Evaluation Order 2
+    override fun visitDeclaration(declaration: FirDeclaration, parent: KtorElement?): List<KtorElement> {
+        return if (declaration is FirSimpleFunction) {
+            declaration.body?.accept(this, parent) ?: emptyList()
+        } else {
+            emptyList()
+        }
+    }
+
+    // Evaluation Order 3
+    override fun visitBlock(block: FirBlock, parent: KtorElement?): List<KtorElement> {
+
+        if (parent is EndPoint) {
+
+            val receiveCall = block.statements.findReceiveCallExpression()
+            val queryParam = block.statements.findQueryParameterExpression()
+
+            if (queryParam.isNotEmpty()) {
+                parent.queryParameters = parent.queryParameters merge queryParam.toSet()
+            }
+
+            if (receiveCall != null) {
+                val kotlinType = receiveCall.resolvedType
+                if (kotlinType.isPrimitiveOrNullablePrimitive || kotlinType.isString || kotlinType.isNullableString) {
+                    parent.body = OpenApiSpec.ObjectType(type = kotlinType.toString().toSwaggerType())
+                } else {
+                    if (config.requestBody) {
+                        parent.body = kotlinType.generateTypeAndVisitMemberDescriptors()
+                    }
+                }
+            }
+        }
+
+        return block.statements.flatMap { it.accept(this, parent) }
+    }
+
+
+    private fun ConeKotlinType.generateTypeAndVisitMemberDescriptors(): OpenApiSpec.ObjectType {
+
+        val jetTypeFqName = fqNameStr()
+
+        val objectType = OpenApiSpec.ObjectType(
+            type = "object",
+            properties = mutableMapOf(),
+            fqName = jetTypeFqName,
+            contentBodyRef = "#/components/schemas/${jetTypeFqName}",
+        )
+        if (!classNames.names.contains(jetTypeFqName)) {
+
+            classNames.add(objectType)
+
+            getMembers(session, config).forEach { d ->
+
+                val classDescriptorVisitor = ClassDescriptorVisitorK2(config, session, context)
+                d.accept(classDescriptorVisitor, objectType)
+                classNames.addAll(classDescriptorVisitor.classNames)
+            }
+        }
+        return objectType
+    }
+
+    private fun List<FirStatement>.findQueryParameterExpression(): List<String> {
+        val queryParams = mutableListOf<String>()
+        flatMap { it.allChildren }.filterIsInstance<FirFunctionCall>()
+            .forEach { it.accept(QueryParamsVisitor(session), queryParams) }
+        return queryParams
+    }
+
+    private fun List<FirStatement>.findReceiveCallExpression(): FirFunctionCall? {
+
+        val receiveFunctionCall = filterIsInstance<FirFunctionCall>()
+            .find { it.toResolvedCallableSymbol()?.callableId?.asSingleFqName() == ClassIds.KTOR_RECEIVE }
+
+        if (receiveFunctionCall == null) {
+            return flatMap { it.allChildren }.filterIsInstance<FirFunctionCall>()
+                .find { it.toResolvedCallableSymbol()?.callableId?.asSingleFqName() == ClassIds.KTOR_RECEIVE }
+        }
+        return receiveFunctionCall
+    }
+
+
+    private fun FirElement?.isKtorApplicationCall(): Boolean {
+        return if (this is FirQualifiedAccessExpression) {
+            extensionReceiver?.resolvedType?.classId == ClassIds.KTOR_APPLICATION
+        } else {
+            false
+        }
+    }
+
+    private fun FirSimpleFunction.isKtorApplicationCall(): Boolean {
+        val classId = receiverParameter?.typeRef?.firClassLike(session)?.classId
+        return classId == ClassIds.KTOR_APPLICATION || classId == ClassIds.KTOR_ROUTE
+    }
+
+    private fun FirQualifiedAccessExpression?.isARouteDefinition(): Boolean {
+        return this?.resolvedType?.classId == ClassIds.KTOR_ROUTE
+    }
+
+
+    @OptIn(SymbolInternals::class)
+    private fun FirFunctionCall.extractArguments(): Map<String, String> {
+        val expression = this
+        val names = (expression.calleeReference.resolved?.resolvedSymbol?.fir as FirFunction).valueParameters.map {
+            it.name.asString()
+        }
+
+        val values = expression.arguments
+            .filterIsInstance<FirLiteralExpression<String>>()
+            .map { it.value }
+
+        return names.zip(values).toMap()
+    }
+
+    private fun FirFunctionCall.findLambda(): FirAnonymousFunctionExpression? {
+        return arguments
+            .filterIsInstance<FirAnonymousFunctionExpression>()
+            .lastOrNull()
+    }
+
+
+    @OptIn(SymbolInternals::class)
+    override fun visitFunctionCall(functionCall: FirFunctionCall, data: KtorElement?): List<KtorElement> {
+        var resultElement: KtorElement? = null
+        val resolvedExp = functionCall.toResolvedCallableReference(session)
+        val expName = resolvedExp?.name?.asString() ?: ""
+
+        val tagsFromAnnotation = functionCall.calleeReference.toResolvedFunctionSymbol()?.fir?.findTags(session)
+        if (functionCall.isARouteDefinition() || ExpType.METHOD.labels.contains(expName)) {
+
+            val args = functionCall.extractArguments()
+
+            val routePathArg = args.entries.find { it.key == "path" }?.value
+
+            if (ExpType.ROUTE.labels.contains(expName)) {
+                if (data == null) {
+                    resultElement = routePathArg?.let {
+                        DocRoute(routePathArg)
+                    } ?: run {
+                        DocRoute(expName)
+                    }
+                } else {
+                    if (data is DocRoute) {
+                        val newElement = DocRoute(
+                            routePathArg.toString(),
+                            tags = data.tags merge tagsFromAnnotation
+                        )
+
+                        resultElement = newElement
+                        data.children.add(newElement)
+                    }
+                }
+            } else if (ExpType.METHOD.labels.contains(expName)) {
+                val (summary, descr, tags) = functionCall.findDocsDescription(session)
+                val responds = functionCall.findRespondsAnnotation(session)
+                val responses = responds?.associate { response ->
+
+                    val kotlinType = response.type
+
+                    val schema = if (kotlinType?.isPrimitiveOrNullablePrimitive == true || kotlinType?.isString == true || kotlinType?.isNullableString == true) {
+                        OpenApiSpec.SchemaType(
+                            type = kotlinType.toString().toSwaggerType()
+                        )
+                    } else {
+
+                        val typeRef = response.type?.generateTypeAndVisitMemberDescriptors()
+                        OpenApiSpec.SchemaType(
+                            `$ref` = "${typeRef?.contentBodyRef}"
+                        )
+                    }
+                    if (!response.isCollection) {
+                        response.status to
+                                OpenApiSpec.ResponseDetails(
+                                    response.descr ?: "",
+                                    mapOf(
+                                        ContentType.APPLICATION_JSON to mapOf(
+                                            "schema" to schema
+                                        )
+                                    )
+                                )
+                    } else {
+                        response.status to
+                                OpenApiSpec.ResponseDetails(
+                                    response.descr ?: "",
+                                    mapOf(
+                                        ContentType.APPLICATION_JSON to mapOf(
+                                            "schema" to OpenApiSpec.SchemaType(
+                                                type = "array",
+                                                items = OpenApiSpec.SchemaRef(
+                                                    type = schema.type,
+                                                    `$ref` = schema.`$ref`
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                    }
+                }
+
+                if (data == null) {
+                    resultElement = routePathArg?.let {
+                        EndPoint(
+                            routePathArg,
+                            expName,
+                            description = descr,
+                            summary = summary,
+                            tags = tags merge tagsFromAnnotation,
+                            responses = responses
+                        )
+                    } ?: EndPoint(
+                        expName,
+                        description = descr,
+                        summary = summary,
+                        tags = tags merge tagsFromAnnotation,
+                        responses = responses
+                    )
+                } else {
+                    if (data is DocRoute) {
+                        val endPoint = EndPoint(
+                            routePathArg,
+                            expName,
+                            description = descr,
+                            summary = summary,
+                            tags = tags merge tagsFromAnnotation,
+                            responses = responses
+                        )
+                        resultElement = endPoint
+                        data.children.add(endPoint)
+                    } else {
+                        log.report(IrMessageLogger.Severity.WARNING, "Endpoints cant have Endpoint as routes", null)
+                    }
+                }
+            }
+        }
+        val lambda = functionCall.findLambda()
+        if (lambda != null) {
+            lambda.accept(this, resultElement ?: data)
+        } else {
+
+            val declaration = functionCall.calleeReference.toResolvedFunctionSymbol()?.fir
+
+            // val tagsFromAnnotation = declaration?.findTags(session)
+
+            if (data is DocRoute) {
+                val accept = declaration?.accept(this, null)
+
+                accept?.onEach {
+                    it.tags = it.tags merge tagsFromAnnotation
+                }
+                data.children.addAll(accept ?: emptyList())
+            } else {
+                declaration?.accept(this, data)
+            }
+        }
+
+        return (resultElement ?: data).wrapAsList()
+    }
+
+
+    override fun visitAnonymousFunctionExpression(
+        anonymousFunctionExpression: FirAnonymousFunctionExpression,
+        data: KtorElement?
+    ): List<KtorElement> = anonymousFunctionExpression.anonymousFunction.body?.accept(this, data) ?: data.wrapAsList()
+
+    override fun visitAnonymousFunction(
+        anonymousFunction: FirAnonymousFunction,
+        parent: KtorElement?
+    ): List<KtorElement> = anonymousFunction.body?.accept(this, parent) ?: parent.wrapAsList()
+
+}
+
+
+internal data class KtorK2ResponseBag(
+    val descr: String,
+    val status: String,
+    val type: ConeKotlinType?,
+    val isCollection: Boolean = false
+)
+
+private fun KtorElement?.wrapAsList() = this?.let { listOf(this) } ?: emptyList()
+
+@OptIn(PrivateForInline::class)
+private fun FirFunctionCall.findDocsDescription(session: FirSession): KtorDescriptionBag {
+    val docsAnnotation = findAnnotation(KtorDescription::class.simpleName!!)
+        ?: return KtorDescriptionBag()
+
+    val resolved = FirExpressionEvaluator.evaluateAnnotationArguments(docsAnnotation, session)
+
+    val summary = resolved?.entries?.find { it.key.asString() == "summary" }?.value?.result
+    val descr = resolved?.entries?.find { it.key.asString() == "description" }?.value?.result
+    val tags = resolved?.entries?.find { it.key.asString() == "tags" }?.value?.result
+
+    return KtorDescriptionBag(
+        summary = summary?.accept(StringResolutionVisitor(), ""),
+        descr = descr?.accept(StringResolutionVisitor(), ""),
+        tags = tags?.accept(StringArrayLiteralVisitor(), emptyList())?.toSet()
+    )
+}
+
+@OptIn(PrivateForInline::class)
+private fun FirFunctionCall.findRespondsAnnotation(session: FirSession): List<KtorK2ResponseBag>? {
+    val annotation = findAnnotation(KtorResponds::class.simpleName!!)
+    return annotation?.let {
+        val resolved = FirExpressionEvaluator.evaluateAnnotationArguments(annotation, session)
+        val mapping = resolved?.entries?.find { it.key.asString() == "mapping" }?.value?.result
+        mapping?.accept(RespondsAnnotationVisitor(), null)
+    }
+}

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/K2Utils.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/K2Utils.kt
@@ -1,0 +1,215 @@
+package io.github.tabilzad.ktor.k2
+
+import io.github.tabilzad.ktor.PluginConfiguration
+import io.github.tabilzad.ktor.byFeatureFlag
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.fullyExpandedClassId
+import org.jetbrains.kotlin.fir.declarations.FirDeclaration
+import org.jetbrains.kotlin.fir.declarations.FirFunction
+import org.jetbrains.kotlin.fir.declarations.FirProperty
+import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.fir.declarations.utils.visibility
+import org.jetbrains.kotlin.fir.expressions.FirAnnotation
+import org.jetbrains.kotlin.fir.expressions.FirExpression
+import org.jetbrains.kotlin.fir.render
+import org.jetbrains.kotlin.fir.resolve.fqName
+import org.jetbrains.kotlin.fir.resolve.toClassSymbol
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.symbols.impl.FirEnumEntrySymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.fir.types.*
+import org.jetbrains.kotlin.fir.visitors.FirVisitorVoid
+import org.jetbrains.kotlin.load.kotlin.internalName
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.StandardClassIds
+
+
+internal class FirstLevelNodeCollector(private val elements: MutableSet<FirElement>) : FirVisitorVoid() {
+    override fun visitElement(element: FirElement) {
+        elements.add(element)
+    }
+}
+
+internal class AllNestedNodeCollector(private val elements: MutableSet<FirElement>) : FirVisitorVoid() {
+    override fun visitElement(element: FirElement) {
+        elements.add(element)
+        element.acceptChildren(this)
+    }
+}
+
+class ExpressionTree(
+    val node: FirElement,
+    val children: MutableList<ExpressionTree> = mutableListOf()
+) {
+
+    fun <T> walk(data: T, onVisit: (FirElement, T) -> List<T>): List<T> {
+        onVisit(node, data)
+        return children.flatMap {
+            walk(data, onVisit)
+        }
+    }
+
+    fun countAll(): Int {
+        return children.fold(children.count()) { acc, expressionTree ->
+            acc + expressionTree.countAll()
+        }
+    }
+
+    fun render(): String {
+        return buildString {
+            append("Node: ${node.render()}")
+            children.forEach {
+                append("Child: " + it.render())
+            }
+        }
+    }
+}
+
+internal class HierarchyResolver(private val root: ExpressionTree) : FirVisitorVoid() {
+
+    override fun visitElement(element: FirElement) {
+        val nextRoot = ExpressionTree(element)
+        root.children.add(nextRoot)
+        element.acceptChildren(HierarchyResolver(nextRoot))
+    }
+}
+
+
+val FirElement.buildHierarchy: ExpressionTree
+    get() {
+        val root = ExpressionTree(this)
+        acceptChildren(HierarchyResolver(root))
+        return root
+    }
+
+internal val FirElement.children: MutableSet<FirElement>
+    get() {
+        val elements = mutableSetOf<FirElement>()
+        acceptChildren(FirstLevelNodeCollector(elements))
+        return elements
+    }
+
+internal val FirElement.allChildren: MutableSet<FirElement>
+    get() {
+        val elements = mutableSetOf<FirElement>()
+        acceptChildren(AllNestedNodeCollector(elements))
+        return elements
+    }
+
+
+internal val FirTypeRef.getKotlinTypeFqName
+    get(): String? {
+        // Ensure the type is resolved
+        val coneType = coneTypeSafe<ConeKotlinType>() ?: return null
+        val classId = coneType.classId
+        return classId?.internalName
+    }
+
+fun FirFunction.hasAnnotation(session: FirSession, name: String): Boolean {
+    return annotations.any { it.fqName(session)?.shortName()?.asString() == name }
+}
+
+fun FirExpression.findAnnotation(name: String): FirAnnotation? {
+    return annotations.firstOrNull {
+        it.annotationTypeRef.coneType.renderReadableWithFqNames().contains(name)
+    }
+}
+
+fun FirProperty.findAnnotation(name: String?): FirAnnotation? {
+    if(name == null) return null
+    return backingField?.annotations?.firstOrNull {
+        it.annotationTypeRef.coneType.renderReadableWithFqNames().contains(name)
+    }
+}
+
+fun FirFunction.findAnnotation(name: String): FirAnnotation? {
+    return annotations.firstOrNull {
+        it.annotationTypeRef.coneType.renderReadableWithFqNames().contains(name)
+    }
+}
+
+fun FirDeclaration.findAnnotation(classId: ClassId, session: FirSession): FirAnnotation? {
+    return annotations.firstOrNull {
+        it.annotationTypeRef.coneType.fullyExpandedClassId(session) == classId
+    }
+}
+
+
+@OptIn(SymbolInternals::class)
+fun ConeKotlinType.getMembers(session: FirSession, config: PluginConfiguration): List<FirDeclaration> {
+
+    val concreteDeclarations =
+        (this as? ConeClassLikeType)?.lookupTag?.toClassSymbol(session)?.fir?.declarations?.filterIsInstance<FirProperty>()
+            ?: emptyList()
+
+    val abstractDeclarations = this.toRegularClassSymbol(session)?.resolvedSuperTypes?.flatMap {
+        it.toRegularClassSymbol(session)?.toLookupTag()?.toClassSymbol(session)?.fir?.declarations ?: emptyList()
+    }?.filterIsInstance<FirProperty>()?.filter { !concreteDeclarations.map { it.name.asString() }.contains(it.name.asString()) } ?: emptyList()
+
+    return (concreteDeclarations + abstractDeclarations).asSequence()
+        .filter { !it.isLocal }
+        .filter {
+            it.visibility.isPublicAPI.byFeatureFlag(config.hidePrivateFields)
+        }
+        .filter {
+            (!it.annotations.hasAnnotation(ClassIds.TRANSIENT_ANNOTATION, session)).byFeatureFlag(config.hideTransients)
+        }
+        .filter {
+            (!(it.backingField?.annotations?.hasAnnotation(ClassIds.TRANSIENT_ANNOTATION, session) == true
+                    || it.delegate?.annotations?.hasAnnotation(ClassIds.TRANSIENT_ANNOTATION, session) == true
+                    || it.setter?.annotations?.hasAnnotation(ClassIds.TRANSIENT_ANNOTATION, session) == true
+                    || it.getter?.annotations?.hasAnnotation(ClassIds.TRANSIENT_ANNOTATION, session) == true)
+                    ).byFeatureFlag(config.hideTransients)
+        }
+        .toList()
+}
+
+fun ConeKotlinType.className(): String? {
+    return (this as? ConeClassLikeType)?.lookupTag?.name?.asString()
+}
+
+fun ConeKotlinType.fqNameStr(): String? {
+    return (this as? ConeClassLikeType)?.lookupTag?.classId?.asFqNameString()
+}
+
+fun ConeKotlinType.isIterable(): Boolean {
+    return isArrayTypeOrNullableArrayType
+            || isArrayType
+            || isArrayOrPrimitiveArray
+            || isList
+            || isMutableList
+            || isSet
+            || isMutableSet
+            || isBuiltinType(StandardClassIds.List, isNullable = true)
+            || isBuiltinType(StandardClassIds.MutableList, isNullable = true)
+            || isBuiltinType(StandardClassIds.Set, isNullable = true)
+            || isBuiltinType(StandardClassIds.MutableSet, isNullable = true)
+            || isBuiltinType(StandardClassIds.Collection, isNullable = false)
+            || isBuiltinType(StandardClassIds.Collection, isNullable = true)
+            || isBuiltinType(StandardClassIds.Iterable, isNullable = false)
+            || isBuiltinType(StandardClassIds.Iterable, isNullable = true)
+            || isBuiltinType(StandardClassIds.Iterator, isNullable = true)
+            || isBuiltinType(StandardClassIds.Iterator, isNullable = false)
+}
+
+fun ConeKotlinType.isMap(): Boolean {
+    return isMap || isMutableMap || isBuiltinType(StandardClassIds.MutableMap, true) ||
+            isBuiltinType(StandardClassIds.Map, true)
+}
+
+private fun ConeKotlinType.isBuiltinType(classId: ClassId, isNullable: Boolean?): Boolean {
+    if (this !is ConeClassLikeType) return false
+    return lookupTag.classId == classId && (isNullable == null || type.isNullable == isNullable)
+}
+
+fun FirRegularClassSymbol.resolveEnumEntries(): List<String> {
+    return declarationSymbols.filterIsInstance<FirEnumEntrySymbol>().map { it.name.asString() }
+}
+
+fun FirRegularClassSymbol.findEnumParamValue(value: String): List<String> {
+    return declarationSymbols.filterIsInstance<FirEnumEntrySymbol>().map { it.name.asString() }
+}
+
+
+

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/QueryParamsVisitor.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/QueryParamsVisitor.kt
@@ -1,0 +1,134 @@
+package io.github.tabilzad.ktor.k2
+
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.FirEvaluatorResult
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.primaryConstructorSymbol
+import org.jetbrains.kotlin.fir.declarations.EnumValueArgumentInfo
+import org.jetbrains.kotlin.fir.declarations.FirProperty
+import org.jetbrains.kotlin.fir.declarations.collectEnumEntries
+import org.jetbrains.kotlin.fir.declarations.extractEnumValueArgumentInfo
+import org.jetbrains.kotlin.fir.declarations.utils.isEnumClass
+import org.jetbrains.kotlin.fir.expressions.*
+import org.jetbrains.kotlin.fir.expressions.impl.FirResolvedArgumentList
+import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
+import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
+import org.jetbrains.kotlin.fir.resolve.toClassSymbol
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.types.toLookupTag
+import org.jetbrains.kotlin.fir.types.toRegularClassSymbol
+import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitor
+
+class QueryParamsVisitor(private val session: FirSession) : FirDefaultVisitor<Unit, MutableList<String>>() {
+
+    override fun visitElement(element: FirElement, data: MutableList<String>) {
+        // no-op
+    }
+
+    override fun visitStringConcatenationCall(
+        stringConcatenationCall: FirStringConcatenationCall,
+        data: MutableList<String>
+    ) {
+        val args = stringConcatenationCall.argumentList.arguments
+        val l = mutableListOf<String>()
+        args.forEach {
+            it.accept(this, l)
+        }
+        data.add(l.joinToString(""))
+    }
+
+
+    override fun visitFunctionCall(functionCall: FirFunctionCall, data: MutableList<String>) {
+        val d = functionCall.dispatchReceiver?.toResolvedCallableSymbol(session)?.callableId?.asSingleFqName()
+        if (d == ClassIds.KTOR_QUERY_PARAM || d == ClassIds.KTOR_RAW_QUERY_PARAM) {
+            functionCall.acceptChildren(this, data)
+        } else {
+            println()
+        }
+    }
+
+
+    override fun <T> visitLiteralExpression(literalExpression: FirLiteralExpression<T>, data: MutableList<String>) {
+        val element = literalExpression.value
+        element?.let { data.add(it.toString()) }
+    }
+
+    @OptIn(SymbolInternals::class)
+    override fun visitResolvedNamedReference(
+        resolvedNamedReference: FirResolvedNamedReference,
+        data: MutableList<String>
+    ) {
+        val fir = resolvedNamedReference.resolvedSymbol.fir
+        if (fir is FirProperty) {
+            val init = fir.initializer
+
+            if (init is FirLiteralExpression<*>) {
+                init.accept(this, data)
+            }
+        }
+    }
+
+    override fun visitArgumentList(argumentList: FirArgumentList, data: MutableList<String>) {
+
+        if (argumentList is FirResolvedArgumentList) {
+            val g = argumentList.mapping.keys
+                .filterIsInstance<FirFunctionCall>()
+                .map {
+                    FirExpressionEvaluator.evaluateExpression(it, session)
+                }.filterIsInstance<FirEvaluatorResult.Evaluated>().map {
+                    it.result
+                }.filterIsInstance<FirLiteralExpression<*>>()
+
+            g.forEach { it.accept(this, data) }
+
+        }
+
+        argumentList.acceptChildren(this, data)
+    }
+
+    @OptIn(SymbolInternals::class)
+    override fun visitPropertyAccessExpression(
+        propertyAccessExpression: FirPropertyAccessExpression,
+        data: MutableList<String>
+    ) {
+
+        val isEnum =
+            propertyAccessExpression.dispatchReceiver?.toResolvedCallableSymbol(session)?.resolvedReturnType?.toRegularClassSymbol(
+                session
+            )?.isEnumClass == true
+        val enumInfo: EnumValueArgumentInfo? = propertyAccessExpression.dispatchReceiver?.extractEnumValueArgumentInfo()
+        val enumEntryAccessor = propertyAccessExpression.calleeReference.toResolvedCallableSymbol()?.name
+
+        if (isEnum) {
+
+            val entries = enumInfo?.enumClassId?.toLookupTag()?.toClassSymbol(session)?.collectEnumEntries()
+            val v = entries?.find { it.name.asString() == enumInfo.enumEntryName.asString() }
+                ?.initializerObjectSymbol
+                ?.primaryConstructorSymbol(session)
+                ?.fir?.delegatedConstructor
+
+            val paramName =
+                v?.resolvedArgumentMapping?.values?.find { it.name.asString() == enumEntryAccessor?.asString() }
+            val paramLiteral = v?.resolvedArgumentMapping?.entries?.find { it.value == paramName }?.key
+
+            val queryParam = (paramLiteral as? FirLiteralExpression<*>)?.value
+            queryParam?.let {
+                data.add(queryParam.toString())
+            }
+        } else {
+            val calleeReference = propertyAccessExpression.calleeReference
+            if (calleeReference is FirResolvedNamedReference) {
+                val fir = calleeReference.resolvedSymbol.fir
+                if (fir is FirProperty) {
+                    val init = fir.initializer
+
+                    if (init is FirLiteralExpression<*>) {
+                        init.accept(this, data)
+                    }
+                }
+            }
+
+        }
+
+    }
+}

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/RespondsAnnotationVisitor.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/RespondsAnnotationVisitor.kt
@@ -1,0 +1,47 @@
+package io.github.tabilzad.ktor.k2
+
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.declarations.FirValueParameter
+import org.jetbrains.kotlin.fir.expressions.*
+import org.jetbrains.kotlin.fir.types.resolvedType
+import org.jetbrains.kotlin.fir.types.type
+import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitor
+
+internal class RespondsAnnotationVisitor : FirDefaultVisitor<List<KtorK2ResponseBag>, KtorK2ResponseBag?>() {
+
+    // if we don't override a particular visit, it will come here by default
+    override fun visitElement(element: FirElement, data: KtorK2ResponseBag?): List<KtorK2ResponseBag> {
+        return emptyList()
+    }
+
+    override fun visitFunctionCall(functionCall: FirFunctionCall, data: KtorK2ResponseBag?): List<KtorK2ResponseBag> {
+
+
+        val status = functionCall.resolvedArgumentMapping?.findValueOfField("status") as? FirLiteralExpression<*>
+        val type = functionCall.resolvedArgumentMapping?.findValueOfField("type") as? FirGetClassCall
+        val isCollection = functionCall.resolvedArgumentMapping?.findValueOfField("isCollection") as? FirLiteralExpression<*>
+        val description =
+            functionCall.resolvedArgumentMapping?.findValueOfField("description") as? FirLiteralExpression<*>
+
+
+        return listOf(
+            KtorK2ResponseBag(
+                descr = description?.accept(StringResolutionVisitor(), "") ?: "",
+                status = status?.accept(StringResolutionVisitor(), "") ?: "UNKNOWN",
+                type = type?.resolvedType?.typeArguments?.firstOrNull()?.type,
+                isCollection = isCollection?.value as? Boolean ?: false
+            )
+        )
+    }
+
+    private fun LinkedHashMap<FirExpression, FirValueParameter>.findValueOfField(name: String): FirExpression? {
+        return entries.find { it.value.name.asString() == name }?.key
+    }
+
+    override fun visitArrayLiteral(arrayLiteral: FirArrayLiteral, data: KtorK2ResponseBag?): List<KtorK2ResponseBag> {
+        return arrayLiteral.arguments.flatMap {
+            it.accept(this, data)
+        }
+    }
+
+}

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/StringArrayLiteralVisitor.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/StringArrayLiteralVisitor.kt
@@ -1,0 +1,24 @@
+package io.github.tabilzad.ktor.k2
+
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.expressions.FirArrayLiteral
+import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
+import org.jetbrains.kotlin.fir.expressions.arguments
+import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitor
+
+internal class StringArrayLiteralVisitor : FirDefaultVisitor<List<String>, List<String>>() {
+
+    // if we don't override a particular visit, it will come here by default
+    override fun visitElement(element: FirElement, data: List<String>): List<String> {
+        return emptyList()
+    }
+
+    override fun <T> visitLiteralExpression(literalExpression: FirLiteralExpression<T>, data: List<String>): List<String> =
+        listOf(literalExpression.value.toString())
+
+    override fun visitArrayLiteral(arrayLiteral: FirArrayLiteral, data: List<String>): List<String> {
+        return arrayLiteral.arguments.flatMap {
+            it.accept(this, data)
+        }
+    }
+}

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/StringResolutionVisitor.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/StringResolutionVisitor.kt
@@ -1,0 +1,19 @@
+package io.github.tabilzad.ktor.k2
+
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
+import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitor
+
+class StringResolutionVisitor : FirDefaultVisitor<String, String>() {
+
+    override fun visitElement(element: FirElement, data: String): String = data
+
+    override fun visitFunctionCall(functionCall: FirFunctionCall, data: String): String =
+        functionCall.dispatchReceiver?.let { dr ->
+            data + dr.accept(this, data)
+        } ?: data
+
+    override fun <T> visitLiteralExpression(literalExpression: FirLiteralExpression<T>, data: String): String =
+        literalExpression.value.toString()
+}

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/SwaggerDeclarationChecker.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/SwaggerDeclarationChecker.kt
@@ -1,0 +1,62 @@
+package io.github.tabilzad.ktor.k2
+
+import io.github.tabilzad.ktor.DocRoute
+import io.github.tabilzad.ktor.annotations.GenerateOpenApi
+import io.github.tabilzad.ktor.buildPluginConfiguration
+import io.github.tabilzad.ktor.convertInternalToOpenSpec
+import io.github.tabilzad.ktor.serializeAndWriteTo
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
+import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirSimpleFunctionChecker
+import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
+import org.jetbrains.kotlin.fir.declarations.hasAnnotation
+import org.jetbrains.kotlin.ir.util.irMessageLogger
+
+
+/**
+ * check function visits all declarations in the code and searches for those annotated with @GenerateOpenApi.
+ * Then the ExpressionVisitor walks through all expressions in the function body to extract Ktor dsl related data
+ * and convert it to Open API specification
+ */
+class SwaggerDeclarationChecker(
+    private val session: FirSession,
+    configuration: CompilerConfiguration
+) : FirSimpleFunctionChecker(MppCheckerKind.Common) {
+
+    private val log = configuration.irMessageLogger
+    private val config = configuration.buildPluginConfiguration()
+
+    override fun check(declaration: FirSimpleFunction, context: CheckerContext, reporter: DiagnosticReporter) {
+        if (
+            declaration.hasAnnotation(ClassIds.KTOR_DOCS_ANNOTATION, session) ||
+            declaration.hasAnnotation(ClassIds.KTOR_GENERATE_ANNOTATION, session) ||
+            declaration.hasAnnotation(session, GenerateOpenApi::class.simpleName!!) ||
+            declaration.hasAnnotation(session, "KtorDocs")
+        ) {
+            val expressionsVisitor = ExpressionsVisitorK2(config, context, session, log)
+            val rawRoutes = declaration.accept(expressionsVisitor, null)
+
+            val routes: List<DocRoute> = if (rawRoutes.any { it !is DocRoute }) {
+                val (routes, endpoints) = rawRoutes.partition { it is DocRoute }
+                val docRoutes = routes as List<DocRoute>
+                docRoutes.plus(DocRoute("/", endpoints.toMutableList()))
+            } else {
+                rawRoutes as List<DocRoute>
+            }
+
+            val components = expressionsVisitor.classNames
+                .associateBy { it.fqName ?: "UNKNOWN" }
+
+            convertInternalToOpenSpec(
+                routes = routes,
+                configuration = config,
+                schemas = components
+            ).serializeAndWriteTo(config)
+        }
+
+
+    }
+}

--- a/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
+++ b/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
@@ -2,7 +2,6 @@ package io.github.tabilzad.ktor
 
 import io.github.tabilzad.ktor.TestSourceUtil.loadSourceAndExpected
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -10,8 +9,7 @@ import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.pathString
 
-@OptIn(ExperimentalCompilerApi::class)
-class StabilityTests {
+class K2StabilityTest {
 
     @TempDir
     lateinit var tempDir: Path
@@ -30,7 +28,7 @@ class StabilityTests {
     fun `should generate correct swagger when KtorDocs annotation is applied to Application`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("Paths1")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
 
         testFile.findSwagger()?.readText().let { generatedSwagger ->
             generatedSwagger.assertWith(expected)
@@ -41,7 +39,7 @@ class StabilityTests {
     fun `should generate correct swagger when KtorDocs annotation is applied to Route`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("Paths2")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
 
         testFile.findSwagger()?.readText().let { generatedSwagger ->
             generatedSwagger.assertWith(expected)
@@ -52,7 +50,7 @@ class StabilityTests {
     fun `should generate correct swagger when KtorDocs annotation is applied to Application with imported or nested routes`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("Paths3")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
 
         testFile.findSwagger()?.readText().let { generatedSwagger ->
             generatedSwagger.assertWith(expected)
@@ -63,7 +61,18 @@ class StabilityTests {
     fun `should generate correct swagger when Route definitions have same path but different endpoint method`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("Paths4")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
+
+        testFile.findSwagger()?.readText().let { generatedSwagger ->
+            generatedSwagger.assertWith(expected)
+        }
+    }
+
+    @Test
+    fun `should generate correct swagger when Route definitions when endpoint http methods don't provide an explicit name`() {
+        val testFile = File(tempDir.toAbsolutePath().pathString)
+        val (source, expected) = loadSourceAndExpected("Paths5")
+        generateCompilerTest(testFile, source)
 
         testFile.findSwagger()?.readText().let { generatedSwagger ->
             generatedSwagger.assertWith(expected)
@@ -74,7 +83,7 @@ class StabilityTests {
     fun `should generate correct post request body`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("RequestBody")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
 
         testFile.findSwagger()?.readText().let { generatedSwagger ->
             generatedSwagger.assertWith(expected)
@@ -85,7 +94,51 @@ class StabilityTests {
     fun `should generate correct post request body 2`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("RequestBody2")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
+
+        testFile.findSwagger()?.readText().let { generatedSwagger ->
+            generatedSwagger.assertWith(expected)
+        }
+    }
+
+    @Test
+    fun `should generate correct post request body 3`() {
+        val testFile = File(tempDir.toAbsolutePath().pathString)
+        val (source, expected) = loadSourceAndExpected("RequestBody3")
+        generateCompilerTest(testFile, source)
+
+        testFile.findSwagger()?.readText().let { generatedSwagger ->
+            generatedSwagger.assertWith(expected)
+        }
+    }
+
+    @Test
+    fun `should include interface fields in request body`() {
+        val testFile = File(tempDir.toAbsolutePath().pathString)
+        val (source, expected) = loadSourceAndExpected("RequestBody3a")
+        generateCompilerTest(testFile, source)
+
+        testFile.findSwagger()?.readText().let { generatedSwagger ->
+            generatedSwagger.assertWith(expected)
+        }
+    }
+
+    @Test
+    fun `should be able to handle generic type definitions in request body`() {
+        val testFile = File(tempDir.toAbsolutePath().pathString)
+        val (source, expected) = loadSourceAndExpected("RequestBody4")
+        generateCompilerTest(testFile, source)
+
+        testFile.findSwagger()?.readText().let { generatedSwagger ->
+            generatedSwagger.assertWith(expected)
+        }
+    }
+
+    @Test
+    fun `should be able to handle generic type definitions wrapped in a collection`() {
+        val testFile = File(tempDir.toAbsolutePath().pathString)
+        val (source, expected) = loadSourceAndExpected("RequestBody5")
+        generateCompilerTest(testFile, source)
 
         testFile.findSwagger()?.readText().let { generatedSwagger ->
             generatedSwagger.assertWith(expected)
@@ -96,7 +149,16 @@ class StabilityTests {
     fun `should generate correct endpoint descriptions`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("EndpointDescription")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
+        val result = testFile.findSwagger()?.readText()
+        result.assertWith(expected)
+    }
+
+    @Test
+    fun `should generate correct body descriptions`() {
+        val testFile = File(tempDir.toAbsolutePath().pathString)
+        val (source, expected) = loadSourceAndExpected("BodyFieldDescription")
+        generateCompilerTest(testFile, source)
         val result = testFile.findSwagger()?.readText()
         result.assertWith(expected)
     }
@@ -105,7 +167,7 @@ class StabilityTests {
     fun `should generate correct swagger definitions for endpoint with path parameters`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("PathParameters")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
         val result = testFile.findSwagger()?.readText()
         result.assertWith(expected)
     }
@@ -114,7 +176,7 @@ class StabilityTests {
     fun `should generate correct swagger definitions for endpoint with path parameters 2`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("PathParameters2")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
         val result = testFile.findSwagger()?.readText()
         result.assertWith(expected)
     }
@@ -123,7 +185,7 @@ class StabilityTests {
     fun `should generate correct swagger definitions for endpoint with path parameters and a body`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("ParamsWithBody")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
         val result = testFile.findSwagger()?.readText()
         result.assertWith(expected)
     }
@@ -132,7 +194,7 @@ class StabilityTests {
     fun `should generate correct swagger definitions for endpoint with query parameters`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("QueryParameters")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
         val result = testFile.findSwagger()?.readText()
         result.assertWith(expected)
     }
@@ -141,7 +203,7 @@ class StabilityTests {
     fun `should generate correct swagger definitions for endpoint with query parameters 2`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("QueryParameters2")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
         val result = testFile.findSwagger()?.readText()
         result.assertWith(expected)
     }
@@ -150,7 +212,7 @@ class StabilityTests {
     fun `should break down endpoints by tag when tags are specified in annotation`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("EndpointDescriptionTags")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
         val result = testFile.findSwagger()?.readText()
         result.assertWith(expected)
     }
@@ -159,7 +221,25 @@ class StabilityTests {
     fun `should break down endpoints by tag when tags are specified at application or route level`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("Tags")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
+        val result = testFile.findSwagger()?.readText()
+        result.assertWith(expected)
+    }
+
+    @Test
+    fun `should break down endpoints by tag when tags are specified at application submodule`() {
+        val testFile = File(tempDir.toAbsolutePath().pathString)
+        val (source, expected) = loadSourceAndExpected("Tags2")
+        generateCompilerTest(testFile, source)
+        val result = testFile.findSwagger()?.readText()
+        result.assertWith(expected)
+    }
+
+    @Test
+    fun `should break down endpoints by tag when tags are specified at application submodule 2`() {
+        val testFile = File(tempDir.toAbsolutePath().pathString)
+        val (source, expected) = loadSourceAndExpected("Tags3")
+        generateCompilerTest(testFile, source)
         val result = testFile.findSwagger()?.readText()
         result.assertWith(expected)
     }
@@ -168,7 +248,7 @@ class StabilityTests {
     fun `should ignore private fields or ones annotated with @Transient`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("PrivateFields")
-        generateArrowTest(testFile, source)
+        generateCompilerTest(testFile, source)
         val result = testFile.findSwagger()?.readText()
         result.assertWith(expected)
     }
@@ -177,7 +257,7 @@ class StabilityTests {
     fun `should include private fields or ones annotated with @Transient`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("PrivateFieldsNegation")
-        generateArrowTest(testFile, source, hideTransient = false, hidePrivate = false)
+        generateCompilerTest(testFile, source, hideTransient = false, hidePrivate = false)
         val result = testFile.findSwagger()?.readText()
         result.assertWith(expected)
     }
@@ -186,7 +266,25 @@ class StabilityTests {
     fun `should generate response correct response bodies when explicitly specified`() {
         val testFile = File(tempDir.toAbsolutePath().pathString)
         val (source, expected) = loadSourceAndExpected("ResponseBody")
-        generateArrowTest(testFile, source, hideTransient = false, hidePrivate = false)
+        generateCompilerTest(testFile, source, hideTransient = false, hidePrivate = false)
+        val result = testFile.findSwagger()?.readText()
+        result.assertWith(expected)
+    }
+
+    @Test
+    fun `should correctly resolve complex descriptions specified on response annotations`() {
+        val testFile = File(tempDir.toAbsolutePath().pathString)
+        val (source, expected) = loadSourceAndExpected("ResponseBody2")
+        generateCompilerTest(testFile, source, hideTransient = false, hidePrivate = false)
+        val result = testFile.findSwagger()?.readText()
+        result.assertWith(expected)
+    }
+
+    @Test
+    fun `should handle abstract or sealed schema definitions`() {
+        val testFile = File(tempDir.toAbsolutePath().pathString)
+        val (source, expected) = loadSourceAndExpected("Abstractions")
+        generateCompilerTest(testFile, source, hideTransient = false, hidePrivate = false)
         val result = testFile.findSwagger()?.readText()
         result.assertWith(expected)
     }

--- a/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/TestUtils.kt
+++ b/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/TestUtils.kt
@@ -1,9 +1,13 @@
 package io.github.tabilzad.ktor
 
-import arrow.meta.plugin.testing.*
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import io.github.classgraph.ClassGraph
+import org.assertj.core.api.Assertions
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import java.io.File
 import java.io.FileNotFoundException
+import java.io.PrintStream
 
 object TestSourceUtil {
     fun loadSourceCodeFrom(fileName: String): String =
@@ -20,6 +24,11 @@ object TestSourceUtil {
             ?: throw FileNotFoundException("annotations don't exist")
     }
 
+    val loadNativeAnnotations by lazy {
+        this.javaClass.getResource("/io/github/tabilzad/ktor/Annotations.kt")
+            ?: throw FileNotFoundException("annotations don't exist")
+    }
+
     val loadRequests by lazy {
         this.javaClass.getResource("/sources/requests/RequestDataClasses.kt")
             ?: throw FileNotFoundException("annotations don't exist")
@@ -30,98 +39,145 @@ object TestSourceUtil {
             ?: throw FileNotFoundException("$fileName does not exist")
 }
 
-fun String.removeTrailingNewLine(): String = if (endsWith(System.lineSeparator())) dropLast(System.lineSeparator().length) else this
+fun String.removeTrailingNewLine(): String =
+    if (endsWith(System.lineSeparator())) dropLast(System.lineSeparator().length) else this
+
+private fun classpathOf(dependency: String): File {
+    val file =
+        ClassGraph().classpathFiles.firstOrNull { classpath ->
+            dependenciesMatch(classpath, dependency)
+        }
+    println("classpath: ${ClassGraph().classpathFiles}")
+    Assertions.assertThat(file)
+        .`as`("$dependency not found in test runtime. Check your build configuration.")
+        .isNotNull
+    return file!!
+}
+
+private fun sanitizeClassPathFileName(dep: String): String =
+    buildList {
+        var skip = false
+        add(dep.first())
+        dep.reduce { a, b ->
+            if (a == '-' && b.isDigit()) skip = true
+            if (!skip) add(b)
+            b
+        }
+        if (skip) removeLast()
+    }
+        .joinToString("")
+        .replace("-jvm.jar", "")
+        .replace("-jvm", "")
+
+
+private fun dependenciesMatch(classpath: File, dependency: String): Boolean {
+    val dep = classpath.name
+    val dependencyName = sanitizeClassPathFileName(dep)
+    val testdep = dependency.substringBefore(":")
+    return testdep == dependencyName
+}
 
 @OptIn(ExperimentalCompilerApi::class)
-fun generateArrowTest(
+fun generateCompilerTest(
     testFile: File,
-    source: String,
+    testSubjectSource: String,
     hideTransient: Boolean = true,
     hidePrivate: Boolean = true,
 ) {
-    assertThis(
-        CompilerTest(
-            config = { getTestConfig(testFile.path, hideTransient, hidePrivate) },
-            assert = { compiles },
-            code = { loadBaseSources(source) })
-    )
-}
 
-fun File.findSwagger() = listFiles()?.find { it.name.contains("openapi.json") }
-fun CompilerTest.Companion.loadBaseSources(source: String): Code {
-    val annotationsFile = TestSourceUtil.loadAnnotations
-    val requestsDefinitions = TestSourceUtil.loadRequests
-    return sources(
-        Code.Source(annotationsFile.file, annotationsFile.readText()),
-        Code.Source(requestsDefinitions.file, requestsDefinitions.readText()),
-        Code.Source("TestSubject.kt", source)
-    )
-}
-
-@ExperimentalCompilerApi
-fun getTestConfig(
-    testFilePath: String,
-    hideTransient: Boolean = true,
-    hidePrivate: Boolean = true,
-): List<Config> {
+    val testFilePath = testFile.path
     val clp = KtorDocsCommandLineProcessor()
-    return listOf(
-        CompilerTest.addMetaPlugins(KtorMetaPluginRegistrar()),
-        CompilerTest.addCommandLineProcessors(clp),
-        CompilerTest.addDependencies(
-            Dependency("ktor:2.2.4"),
-            Dependency("ktor-server-core:2.2.4"),
-            Dependency("ktor-utils:2.2.4"),
-            Dependency("ktor-server-netty:2.2.4"),
-            Dependency("ktor-http:2.2.4"),
-            Dependency("kotlinx-coroutines-core:1.6.4")
-        ),
-        CompilerTest.addPluginOptions(
-            PluginOption(
+    val compilationData = KotlinCompilation().apply {
+        val testSources = workingDir.resolve("sources")
+        System.setProperty("arrow.meta.generate.source.dir", testSources.absolutePath)
+        compilerPluginRegistrars = listOf(KtorMetaPluginRegistrar())
+        commandLineProcessors = listOf(clp)
+        classpaths = deps.map { classpathOf(it) }
+        val loadBaseSources2 = loadBaseSources2(testSubjectSource)
+        sources = loadBaseSources2
+        kotlincArguments = emptyList()
+        jvmTarget = "1.8"
+        messageOutputStream =
+            object : PrintStream(System.out) {
+
+                private val kotlincErrorRegex = Regex("^e:")
+
+                override fun write(buf: ByteArray, off: Int, len: Int) {
+                    val newLine =
+                        String(buf, off, len).run { replace(kotlincErrorRegex, "error found:") }.toByteArray()
+
+                    super.write(newLine, off, newLine.size)
+                }
+            }
+        pluginOptions = listOf(
+            com.tschuchort.compiletesting.PluginOption(
                 clp.pluginId,
                 KtorDocsCommandLineProcessor.isEnabled.optionName,
                 "true"
             ),
-            PluginOption(
+            com.tschuchort.compiletesting.PluginOption(
                 clp.pluginId,
                 KtorDocsCommandLineProcessor.requestSchema.optionName,
                 "true"
             ),
-            PluginOption(
+            com.tschuchort.compiletesting.PluginOption(
                 clp.pluginId,
                 KtorDocsCommandLineProcessor.descOption.optionName,
                 "test"
             ),
-            PluginOption(
+            com.tschuchort.compiletesting.PluginOption(
                 clp.pluginId,
                 KtorDocsCommandLineProcessor.formatOption.optionName,
                 "json"
             ),
-            PluginOption(
+            com.tschuchort.compiletesting.PluginOption(
                 clp.pluginId,
                 KtorDocsCommandLineProcessor.pathOption.optionName,
                 testFilePath
             ),
-            PluginOption(
+            com.tschuchort.compiletesting.PluginOption(
                 clp.pluginId,
                 KtorDocsCommandLineProcessor.buildPath.optionName,
                 testFilePath
             ),
-            PluginOption(
+            com.tschuchort.compiletesting.PluginOption(
                 clp.pluginId,
                 KtorDocsCommandLineProcessor.modulePath.optionName,
                 testFilePath
             ),
-            PluginOption(
+            com.tschuchort.compiletesting.PluginOption(
                 clp.pluginId,
                 KtorDocsCommandLineProcessor.hideTransientFields.optionName,
                 hideTransient.toString()
             ),
-            PluginOption(
+            com.tschuchort.compiletesting.PluginOption(
                 clp.pluginId,
                 KtorDocsCommandLineProcessor.hidePrivateAndInternalFields.optionName,
                 hidePrivate.toString()
             )
         )
+    }
+    compilationData.compile()
+}
+
+fun File.findSwagger() = listFiles()?.find { it.name.contains("openapi.json") }
+
+fun loadBaseSources2(source: String): List<SourceFile> {
+    val annotationsFile = TestSourceUtil.loadAnnotations
+    val nativeAnnotationsFile = TestSourceUtil.loadNativeAnnotations
+    val requestsDefinitions = TestSourceUtil.loadRequests
+    return listOf(
+        SourceFile.kotlin(annotationsFile.file, annotationsFile.readText().trimMargin()),
+        SourceFile.kotlin(nativeAnnotationsFile.file, nativeAnnotationsFile.readText().trimMargin()),
+        SourceFile.kotlin(requestsDefinitions.file, requestsDefinitions.readText().trimMargin()),
+        SourceFile.kotlin("TestSubject.kt", source)
     )
 }
+
+val deps = arrayOf(
+    "ktor:2.2.4",
+    "ktor-server-core:2.2.4",
+    "ktor-utils:2.2.4",
+    "ktor-server-netty:2.2.4",
+    "ktor-http:2.2.4",
+    "kotlinx-coroutines-core:1.6.4")

--- a/create-plugin/src/test/resources/expected/Abstractions-expected.json
+++ b/create-plugin/src/test/resources/expected/Abstractions-expected.json
@@ -1,0 +1,68 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "Open API Specification",
+    "description" : "test",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/v1/action" : {
+      "post" : {
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/sources.RequestBody"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "sources.Action" : {
+        "type" : "object",
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/sources.ActionOne"
+        }, {
+          "$ref" : "#/components/schemas/sources.ActionThree"
+        }, {
+          "$ref" : "#/components/schemas/sources.ActionTwo"
+        } ]
+      },
+      "sources.ActionOne" : {
+        "type" : "object",
+        "properties" : {
+          "field" : {
+            "type" : "integer"
+          }
+        },
+        "required" : [ "field" ]
+      },
+      "sources.ActionThree" : {
+        "type" : "object"
+      },
+      "sources.ActionTwo" : {
+        "type" : "object",
+        "properties" : {
+          "value" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "value" ]
+      },
+      "sources.RequestBody" : {
+        "type" : "object",
+        "properties" : {
+          "action" : {
+            "$ref" : "#/components/schemas/sources.Action"
+          }
+        },
+        "required" : [ "action" ]
+      }
+    }
+  }
+}

--- a/create-plugin/src/test/resources/expected/BodyFieldDescription-expected.json
+++ b/create-plugin/src/test/resources/expected/BodyFieldDescription-expected.json
@@ -1,0 +1,63 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "Open API Specification",
+    "description" : "test",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/v1/requestWithDescribedFields" : {
+      "post" : {
+        "summary" : "My Summary",
+        "description" : "My Description",
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/sources.MyDescribedPayload"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "sources.MyDescribedPayload" : {
+        "type" : "object",
+        "properties" : {
+          "field1" : {
+            "type" : "string",
+            "description" : "this is field 1 (string)"
+          },
+          "field2" : {
+            "type" : "integer",
+            "description" : "this is field 2 (int)"
+          },
+          "field3" : {
+            "description" : "this is field 3 (int)",
+            "$ref" : "#/components/schemas/sources.NestedObject"
+          }
+        },
+        "required" : [ "field1", "field3" ]
+      },
+      "sources.NestedObject" : {
+        "type" : "object",
+        "properties" : {
+          "subField" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "subField2" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "subField" ]
+      }
+    }
+  }
+}

--- a/create-plugin/src/test/resources/expected/EndpointDescriptionTags-expected.json
+++ b/create-plugin/src/test/resources/expected/EndpointDescriptionTags-expected.json
@@ -36,7 +36,7 @@
       "get" : {
         "summary" : "My Summary",
         "description" : "My Description",
-        "tags" : [ "module2", "tag1", "subModule" ]
+        "tags" : [ "module2", "subModule", "tag1" ]
       }
     },
     "/v2/subRoute1/tagged1AndModule2" : {

--- a/create-plugin/src/test/resources/expected/ParamsWithBody-expected.json
+++ b/create-plugin/src/test/resources/expected/ParamsWithBody-expected.json
@@ -34,16 +34,17 @@
       "sources.requests.SimpleRequest" : {
         "type" : "object",
         "properties" : {
-          "string" : {
-            "type" : "string"
+          "float" : {
+            "type" : "number"
           },
           "integer" : {
             "type" : "integer"
           },
-          "float" : {
-            "type" : "number"
+          "string" : {
+            "type" : "string"
           }
-        }
+        },
+        "required" : [ "string", "integer", "float" ]
       }
     }
   }

--- a/create-plugin/src/test/resources/expected/PathParameters2-expected.json
+++ b/create-plugin/src/test/resources/expected/PathParameters2-expected.json
@@ -56,16 +56,17 @@
       "sources.requests.SimpleRequest" : {
         "type" : "object",
         "properties" : {
-          "string" : {
-            "type" : "string"
+          "float" : {
+            "type" : "number"
           },
           "integer" : {
             "type" : "integer"
           },
-          "float" : {
-            "type" : "number"
+          "string" : {
+            "type" : "string"
           }
-        }
+        },
+        "required" : [ "string", "integer", "float" ]
       }
     }
   }

--- a/create-plugin/src/test/resources/expected/Paths5-expected.json
+++ b/create-plugin/src/test/resources/expected/Paths5-expected.json
@@ -1,0 +1,19 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "Open API Specification",
+    "description" : "test",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/v1/else" : {
+      "post" : { }
+    },
+    "/v1/else1" : {
+      "get" : { }
+    }
+  },
+  "components" : {
+    "schemas" : { }
+  }
+}

--- a/create-plugin/src/test/resources/expected/PrivateFields-expected.json
+++ b/create-plugin/src/test/resources/expected/PrivateFields-expected.json
@@ -29,7 +29,8 @@
           "visible" : {
             "type" : "boolean"
           }
-        }
+        },
+        "required" : [ "visible" ]
       }
     }
   }

--- a/create-plugin/src/test/resources/expected/QueryParameters2-expected.json
+++ b/create-plugin/src/test/resources/expected/QueryParameters2-expected.json
@@ -103,16 +103,17 @@
       "sources.requests.SimpleRequest" : {
         "type" : "object",
         "properties" : {
-          "string" : {
-            "type" : "string"
+          "float" : {
+            "type" : "number"
           },
           "integer" : {
             "type" : "integer"
           },
-          "float" : {
-            "type" : "number"
+          "string" : {
+            "type" : "string"
           }
-        }
+        },
+        "required" : [ "string", "integer", "float" ]
       }
     }
   }

--- a/create-plugin/src/test/resources/expected/RequestBody-expected.json
+++ b/create-plugin/src/test/resources/expected/RequestBody-expected.json
@@ -85,64 +85,34 @@
           "something" : {
             "type" : "string"
           }
-        }
+        },
+        "required" : [ "something" ]
       },
       "sources.requests.ComplexRequest" : {
         "type" : "object",
         "properties" : {
-          "evenMore" : {
-            "type" : "integer"
-          },
-          "list" : {
-            "type" : "array",
+          "complexEnumValueMap" : {
+            "type" : "object",
             "properties" : { },
-            "items" : {
-              "type" : "string"
-            }
-          },
-          "nestedList" : {
-            "type" : "array",
-            "properties" : { },
-            "items" : {
+            "additionalProperties" : {
               "type" : "array",
-              "properties" : { },
               "items" : {
-                "type" : "string"
-              }
-            }
-          },
-          "nestedMutableList" : {
-            "type" : "array",
-            "properties" : { },
-            "items" : {
-              "type" : "array",
-              "properties" : { },
-              "items" : {
-                "type" : "array",
-                "properties" : { },
-                "items" : {
-                  "type" : "array",
-                  "properties" : { },
-                  "items" : {
-                    "type" : "string"
-                  }
-                }
+                "type" : "string",
+                "enum" : [ "ONE", "TWO", "THREE" ]
               }
             }
           },
           "complexList" : {
             "type" : "array",
-            "properties" : { },
             "items" : {
               "$ref" : "#/components/schemas/sources.requests.ComplexMapValue"
             }
           },
-          "complexNestedList" : {
-            "type" : "array",
+          "complexListMap" : {
+            "type" : "object",
             "properties" : { },
-            "items" : {
+            "additionalProperties" : {
               "type" : "array",
-              "properties" : { },
               "items" : {
                 "$ref" : "#/components/schemas/sources.requests.ComplexMapValue"
               }
@@ -153,18 +123,15 @@
             "properties" : { },
             "additionalProperties" : {
               "type" : "array",
-              "properties" : { },
               "items" : {
                 "type" : "string"
               }
             }
           },
-          "complexListMap" : {
-            "type" : "object",
-            "properties" : { },
-            "additionalProperties" : {
+          "complexNestedList" : {
+            "type" : "array",
+            "items" : {
               "type" : "array",
-              "properties" : { },
               "items" : {
                 "$ref" : "#/components/schemas/sources.requests.ComplexMapValue"
               }
@@ -175,28 +142,12 @@
             "properties" : { },
             "additionalProperties" : {
               "type" : "array",
-              "properties" : { },
               "items" : {
                 "type" : "array",
-                "properties" : { },
                 "items" : {
                   "$ref" : "#/components/schemas/sources.requests.ComplexMapValue"
                 }
               }
-            }
-          },
-          "stringMap" : {
-            "type" : "object",
-            "properties" : { },
-            "additionalProperties" : {
-              "type" : "string"
-            }
-          },
-          "intValueMap" : {
-            "type" : "object",
-            "properties" : { },
-            "additionalProperties" : {
-              "type" : "integer"
             }
           },
           "complexValueMap" : {
@@ -211,23 +162,58 @@
             "properties" : { },
             "additionalProperties" : {
               "type" : "string",
-              "enum" : [ "TWO", "THREE", "ONE" ]
+              "enum" : [ "ONE", "TWO", "THREE" ]
             }
           },
-          "complexEnumValueMap" : {
+          "evenMore" : {
+            "type" : "integer"
+          },
+          "intValueMap" : {
             "type" : "object",
             "properties" : { },
             "additionalProperties" : {
+              "type" : "integer"
+            }
+          },
+          "list" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "nestedList" : {
+            "type" : "array",
+            "items" : {
               "type" : "array",
-              "properties" : { },
               "items" : {
-                "type" : "string",
-                "properties" : { },
-                "enum" : [ "ONE", "TWO", "THREE" ]
+                "type" : "string"
               }
             }
+          },
+          "nestedMutableList" : {
+            "type" : "array",
+            "items" : {
+              "type" : "array",
+              "items" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            }
+          },
+          "stringMap" : {
+            "type" : "object",
+            "properties" : { },
+            "additionalProperties" : {
+              "type" : "string"
+            }
           }
-        }
+        },
+        "required" : [ "list", "nestedList", "nestedMutableList", "complexList", "complexNestedList", "complexListStringMap", "complexListMap", "complexNestedListMap", "stringMap", "intValueMap", "complexValueMap", "enumValueMap", "complexEnumValueMap" ]
       },
       "sources.requests.NestedRequest" : {
         "type" : "object",
@@ -235,21 +221,23 @@
           "nestedObject" : {
             "$ref" : "#/components/schemas/sources.requests.SimpleRequest"
           }
-        }
+        },
+        "required" : [ "nestedObject" ]
       },
       "sources.requests.SimpleRequest" : {
         "type" : "object",
         "properties" : {
-          "string" : {
-            "type" : "string"
+          "float" : {
+            "type" : "number"
           },
           "integer" : {
             "type" : "integer"
           },
-          "float" : {
-            "type" : "number"
+          "string" : {
+            "type" : "string"
           }
-        }
+        },
+        "required" : [ "string", "integer", "float" ]
       }
     }
   }

--- a/create-plugin/src/test/resources/expected/RequestBody2-expected.json
+++ b/create-plugin/src/test/resources/expected/RequestBody2-expected.json
@@ -42,16 +42,17 @@
       "sources.requests.SimpleRequest" : {
         "type" : "object",
         "properties" : {
-          "string" : {
-            "type" : "string"
+          "float" : {
+            "type" : "number"
           },
           "integer" : {
             "type" : "integer"
           },
-          "float" : {
-            "type" : "number"
+          "string" : {
+            "type" : "string"
           }
-        }
+        },
+        "required" : [ "string", "integer", "float" ]
       }
     }
   }

--- a/create-plugin/src/test/resources/expected/RequestBody3-expected.json
+++ b/create-plugin/src/test/resources/expected/RequestBody3-expected.json
@@ -6,14 +6,14 @@
     "version" : "1.0.0"
   },
   "paths" : {
-    "/v1/bodyWithPrivateFields" : {
+    "/v3/postBodyRequestSimple" : {
       "post" : {
         "requestBody" : {
           "required" : true,
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/sources.requests.PrivateBodyRequest"
+                "$ref" : "#/components/schemas/sources.SomeRequest"
               }
             }
           }
@@ -23,20 +23,16 @@
   },
   "components" : {
     "schemas" : {
-      "sources.requests.PrivateBodyRequest" : {
+      "sources.SomeRequest" : {
         "type" : "object",
         "properties" : {
-          "invisible" : {
-            "type" : "string"
-          },
-          "transientFieldInvisible" : {
-            "type" : "integer"
-          },
-          "visible" : {
-            "type" : "boolean"
+          "myEnum" : {
+            "type" : "string",
+            "enum" : [ "ENTRY1", "ENTRY2" ],
+            "description" : "this is an enum field"
           }
         },
-        "required" : [ "visible", "invisible", "transientFieldInvisible" ]
+        "required" : [ "myEnum" ]
       }
     }
   }

--- a/create-plugin/src/test/resources/expected/RequestBody3a-expected.json
+++ b/create-plugin/src/test/resources/expected/RequestBody3a-expected.json
@@ -6,14 +6,14 @@
     "version" : "1.0.0"
   },
   "paths" : {
-    "/v1/bodyWithPrivateFields" : {
+    "/v3/postBodyRequestSimple" : {
       "post" : {
         "requestBody" : {
           "required" : true,
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/sources.requests.PrivateBodyRequest"
+                "$ref" : "#/components/schemas/sources.SomeRequest"
               }
             }
           }
@@ -23,20 +23,23 @@
   },
   "components" : {
     "schemas" : {
-      "sources.requests.PrivateBodyRequest" : {
+      "sources.SomeRequest" : {
         "type" : "object",
         "properties" : {
-          "invisible" : {
+          "abstractField1" : {
             "type" : "string"
           },
-          "transientFieldInvisible" : {
+          "abstractField2" : {
             "type" : "integer"
           },
-          "visible" : {
-            "type" : "boolean"
+          "concreteField" : {
+            "type" : "string"
+          },
+          "fieldWithGetter" : {
+            "type" : "string"
           }
         },
-        "required" : [ "visible", "invisible", "transientFieldInvisible" ]
+        "required" : [ "concreteField", "abstractField1", "abstractField2", "fieldWithGetter" ]
       }
     }
   }

--- a/create-plugin/src/test/resources/expected/RequestBody4-expected.json
+++ b/create-plugin/src/test/resources/expected/RequestBody4-expected.json
@@ -6,14 +6,14 @@
     "version" : "1.0.0"
   },
   "paths" : {
-    "/v1/bodyWithPrivateFields" : {
+    "/v3/postGenericRequest" : {
       "post" : {
         "requestBody" : {
           "required" : true,
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/sources.requests.PrivateBodyRequest"
+                "$ref" : "#/components/schemas/sources.SomeGenericRequest"
               }
             }
           }
@@ -23,20 +23,26 @@
   },
   "components" : {
     "schemas" : {
-      "sources.requests.PrivateBodyRequest" : {
+      "sources.GenericType" : {
         "type" : "object",
         "properties" : {
-          "invisible" : {
+          "other" : {
             "type" : "string"
           },
-          "transientFieldInvisible" : {
+          "status" : {
             "type" : "integer"
-          },
-          "visible" : {
-            "type" : "boolean"
           }
         },
-        "required" : [ "visible", "invisible", "transientFieldInvisible" ]
+        "required" : [ "status", "other" ]
+      },
+      "sources.SomeGenericRequest" : {
+        "type" : "object",
+        "properties" : {
+          "generic" : {
+            "$ref" : "#/components/schemas/sources.GenericType"
+          }
+        },
+        "required" : [ "generic" ]
       }
     }
   }

--- a/create-plugin/src/test/resources/expected/RequestBody5-expected.json
+++ b/create-plugin/src/test/resources/expected/RequestBody5-expected.json
@@ -1,0 +1,55 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "Open API Specification",
+    "description" : "test",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/v3/postGenericRequest" : {
+      "post" : {
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/sources.SomeGenericRequest"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "sources.GenericType" : {
+        "type" : "object",
+        "properties" : {
+          "other" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "integer"
+          }
+        },
+        "required" : [ "status", "other" ]
+      },
+      "sources.SomeGenericRequest" : {
+        "type" : "object",
+        "properties" : {
+          "generic" : {
+            "type" : "array",
+            "items" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/sources.GenericType"
+              }
+            }
+          }
+        },
+        "required" : [ "generic" ]
+      }
+    }
+  }
+}

--- a/create-plugin/src/test/resources/expected/ResponseBody2-expected.json
+++ b/create-plugin/src/test/resources/expected/ResponseBody2-expected.json
@@ -6,11 +6,11 @@
     "version" : "1.0.0"
   },
   "paths" : {
-    "/v1/postBodyRequestSimple" : {
+    "/v5/postBodyRequestSimple" : {
       "post" : {
         "responses" : {
           "200" : {
-            "description" : "Success",
+            "description" : "line0line1line3",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -20,7 +20,7 @@
             }
           },
           "500" : {
-            "description" : "Failure",
+            "description" : "external",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -42,15 +42,18 @@
         }
       }
     },
-    "/v1/implicitArgNames" : {
+    "/v5/implicitField" : {
       "post" : {
         "responses" : {
           "200" : {
-            "description" : "",
+            "description" : "line0line1line3",
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/sources.requests.SimpleRequest"
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/sources.requests.SimpleRequest"
+                  }
                 }
               }
             }
@@ -68,8 +71,8 @@
         }
       }
     },
-    "/v1/listOfs" : {
-      "post" : {
+    "/v5/implicitArgs" : {
+      "get" : {
         "responses" : {
           "200" : {
             "description" : "",

--- a/create-plugin/src/test/resources/expected/Tags2-expected.json
+++ b/create-plugin/src/test/resources/expected/Tags2-expected.json
@@ -1,0 +1,23 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "Open API Specification",
+    "description" : "test",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/submodule1/sub1" : {
+      "get" : {
+        "tags" : [ "Module" ]
+      }
+    },
+    "/submodule2/sub2" : {
+      "get" : {
+        "tags" : [ "Module", "SubModule" ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : { }
+  }
+}

--- a/create-plugin/src/test/resources/expected/Tags3-expected.json
+++ b/create-plugin/src/test/resources/expected/Tags3-expected.json
@@ -1,0 +1,23 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "Open API Specification",
+    "description" : "test",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/l1/sub_l1/sub_l1_get" : {
+      "get" : {
+        "tags" : [ "MainModule", "SubModule" ]
+      }
+    },
+    "/l1/l2/l2get" : {
+      "get" : {
+        "tags" : [ "MainModule" ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : { }
+  }
+}

--- a/create-plugin/src/test/resources/io/github/tabilzad/ktor/Annotations.kt
+++ b/create-plugin/src/test/resources/io/github/tabilzad/ktor/Annotations.kt
@@ -2,9 +2,20 @@ package io.github.tabilzad.ktor
 
 import kotlin.reflect.KClass
 
+@Deprecated("Please use @GenerateOpenApi")
+typealias KtorDocs = GenerateOpenApi
+
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.EXPRESSION)
-annotation class KtorDocs(val tags: Array<String> = [])
+annotation class GenerateOpenApi
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.EXPRESSION)
+annotation class IgnoreOpenApi
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.EXPRESSION)
+annotation class Tag(val tags: Array<String> = [])
 
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.EXPRESSION)
@@ -26,8 +37,19 @@ annotation class ResponseEntry(
     AnnotationTarget.CLASS,
     AnnotationTarget.FUNCTION,
     AnnotationTarget.EXPRESSION)
-annotation class KtorDescription(val summary: String = "", val description: String = "", val tags: Array<String> = [])
+annotation class KtorDescription(
+    val summary: String = "",
+    val description: String = "",
+    val required: Boolean = false,
+    val tags: Array<String> = [])
 
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD, AnnotationTarget.CLASS)
+annotation class KtorFieldDescription(
+    val summary: String = "",
+    val description: String = "",
+    val required: Boolean = false,
+    val tags: Array<String> = [])
 
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS)

--- a/create-plugin/src/test/resources/sources/Abstractions.kt
+++ b/create-plugin/src/test/resources/sources/Abstractions.kt
@@ -1,0 +1,29 @@
+package sources
+
+import io.github.tabilzad.ktor.GenerateOpenApi
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.routing.*
+
+
+sealed class Action()
+
+data class ActionOne(val field: Int) : Action()
+data class ActionTwo(val value: String) : Action()
+data object ActionThree : Action()
+
+data class RequestBody(
+    val action: Action
+)
+
+@GenerateOpenApi
+fun Application.module1() {
+    routing {
+        route("/v1") {
+
+            post("/action") {
+                call.receive<RequestBody>()
+            }
+        }
+    }
+}

--- a/create-plugin/src/test/resources/sources/BodyFieldDescription.kt
+++ b/create-plugin/src/test/resources/sources/BodyFieldDescription.kt
@@ -1,0 +1,41 @@
+package sources
+
+import io.ktor.server.routing.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.routing.*
+import sources.annotations.KtorDescription
+import sources.annotations.KtorDocs
+import io.github.tabilzad.ktor.*
+
+
+data class MyDescribedPayload(
+    @KtorFieldDescription("this is field 1 (string)", required = true)
+    val field1: String,
+    @KtorFieldDescription("this is field 2 (int)", required = false)
+    val field2: Int,
+    @KtorFieldDescription("this is field 3 (int)")
+    val field3: NestedObject
+)
+
+data class NestedObject(
+    @KtorFieldDescription(required = true)
+    val subField: List<String>,
+    @KtorFieldDescription(required = false)
+    val subField2: String
+)
+
+@KtorDocs
+fun Application.testDescription() {
+    routing {
+        route("/v1") {
+            @KtorDescription(
+                "My Summary",
+                description = "My Description"
+            )
+            post("/requestWithDescribedFields") {
+                call.receive<MyDescribedPayload>()
+            }
+        }
+    }
+}

--- a/create-plugin/src/test/resources/sources/EndpointDescriptionTags.kt
+++ b/create-plugin/src/test/resources/sources/EndpointDescriptionTags.kt
@@ -1,11 +1,13 @@
 package sources
 
+import io.github.tabilzad.ktor.KtorDocs
+import io.github.tabilzad.ktor.Tag
 import io.ktor.server.application.Application
 import io.ktor.server.routing.*
 import sources.annotations.KtorDescription
-import sources.annotations.KtorDocs
 
-@KtorDocs(["module1"])
+@KtorDocs
+@Tag(["module1"])
 fun Application.testDescriptionTags() {
     routing {
         route("/v1") {
@@ -45,7 +47,8 @@ fun Application.testDescriptionTags() {
     }
 }
 
-@KtorDocs(["module2"])
+@KtorDocs
+@Tag(["module2"])
 fun Application.testDescriptionTags2() {
     routing {
         route("/v2") {
@@ -68,7 +71,8 @@ fun Application.testDescriptionTags2() {
     }
 }
 
-@KtorDocs(["subModule"])
+@KtorDocs
+@Tag(["subModule"])
 fun Route.subRouteWithSpecialTag(){
 
     route("/subRoute2") {

--- a/create-plugin/src/test/resources/sources/Paths5.kt
+++ b/create-plugin/src/test/resources/sources/Paths5.kt
@@ -1,0 +1,23 @@
+package sources
+
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
+import sources.annotations.KtorDocs
+
+@KtorDocs
+fun Application.testRoute() {
+    routing {
+        route("/v1") {
+            route("else") {
+                post {
+
+                }
+            }
+            route("else1") {
+                get {
+
+                }
+            }
+        }
+    }
+}

--- a/create-plugin/src/test/resources/sources/QueryParameters.kt
+++ b/create-plugin/src/test/resources/sources/QueryParameters.kt
@@ -54,11 +54,14 @@ fun Application.queryParametersTest() {
             }
             get("/order6") {
                 call.request.queryParameters[queryParam].let{
+                    val k = "notParam"+ "notParam"
+
                     println(it)
                 }
             }
             get("/order7") {
                 call.request.queryParameters["param_part1" + "param_part2"].let{
+                    "notParam"+ "notParam"
                     println(it)
                 }
             }

--- a/create-plugin/src/test/resources/sources/RequestBody2.kt
+++ b/create-plugin/src/test/resources/sources/RequestBody2.kt
@@ -1,5 +1,6 @@
 package sources
 
+import io.github.tabilzad.ktor.Tag
 import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.routing.*
@@ -8,14 +9,16 @@ import sources.annotations.KtorDocs
 import sources.requests.ComplexRequest
 import sources.requests.SimpleRequest
 
-@KtorDocs(["module1"])
+@KtorDocs
+@Tag(["module1"])
 fun Application.module1() {
     routing {
         requestBodyTest2()
     }
 }
 
-@KtorDocs(["submodule"])
+@KtorDocs
+@Tag(["submodule"])
 fun Route.requestBodyTest2() {
 
     val service = MyService2()

--- a/create-plugin/src/test/resources/sources/RequestBody3.kt
+++ b/create-plugin/src/test/resources/sources/RequestBody3.kt
@@ -1,0 +1,29 @@
+package sources
+
+import sources.annotations.KtorDescription
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import sources.annotations.KtorDocs
+
+enum class MyEnumClass{
+    ENTRY1,
+    ENTRY2
+}
+
+data class SomeRequest(
+    @KtorDescription("this is an enum field")
+    val myEnum: MyEnumClass
+)
+@KtorDocs
+fun Application.responseBody() {
+    routing {
+        route("/v3") {
+            post("/postBodyRequestSimple") {
+                call.receive<SomeRequest>()
+            }
+        }
+    }
+}

--- a/create-plugin/src/test/resources/sources/RequestBody3a.kt
+++ b/create-plugin/src/test/resources/sources/RequestBody3a.kt
@@ -1,0 +1,31 @@
+package sources
+
+import sources.annotations.KtorDescription
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import sources.annotations.KtorDocs
+
+interface MyInterface {
+    val abstractField1: String,
+    val abstractField2: Int,
+    val fieldWithGetter: String
+        get() = abstractField1 + abstractField2.toString()
+}
+
+data class SomeRequest(
+    val concreteField: String
+) : MyInterface
+
+@KtorDocs
+fun Application.responseBody() {
+    routing {
+        route("/v3") {
+            post("/postBodyRequestSimple") {
+                call.receive<SomeRequest>()
+            }
+        }
+    }
+}

--- a/create-plugin/src/test/resources/sources/RequestBody4.kt
+++ b/create-plugin/src/test/resources/sources/RequestBody4.kt
@@ -1,0 +1,30 @@
+package sources
+
+import io.github.tabilzad.ktor.GenerateOpenApi
+import sources.annotations.KtorDescription
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import sources.annotations.KtorDocs
+
+data class GenericType<T>(
+    val status: T,
+    val other: String
+)
+
+data class SomeGenericRequest(
+    val generic: GenericType<Int>
+)
+
+@GenerateOpenApi
+fun Application.responseBody() {
+    routing {
+        route("/v3") {
+            post("/postGenericRequest") {
+                call.receive<SomeGenericRequest>()
+            }
+        }
+    }
+}

--- a/create-plugin/src/test/resources/sources/RequestBody5.kt
+++ b/create-plugin/src/test/resources/sources/RequestBody5.kt
@@ -1,0 +1,30 @@
+package sources
+
+import io.github.tabilzad.ktor.GenerateOpenApi
+import sources.annotations.KtorDescription
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import sources.annotations.KtorDocs
+
+data class GenericType<T>(
+    val status: T,
+    val other: String
+)
+
+data class SomeGenericRequest(
+    val generic: List<List<GenericType<Int>>
+)
+
+@GenerateOpenApi
+fun Application.responseBody() {
+    routing {
+        route("/v3") {
+            post("/postGenericRequest") {
+                call.receive<SomeGenericRequest>()
+            }
+        }
+    }
+}

--- a/create-plugin/src/test/resources/sources/ResponseBody2.kt
+++ b/create-plugin/src/test/resources/sources/ResponseBody2.kt
@@ -1,0 +1,51 @@
+package sources
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import sources.annotations.KtorDocs
+import sources.annotations.KtorResponds
+import sources.annotations.ResponseEntry
+import sources.requests.PrivateBodyRequest
+import sources.requests.SimpleRequest
+
+const val externalDesc = "external"
+
+@KtorDocs
+fun Application.responseBody() {
+    routing {
+        route("/v5") {
+            @KtorResponds(
+                mapping = [
+                    ResponseEntry(
+                        "200", SimpleRequest::class, description = "line0" + "line1"
+                                + "line3"
+                    ),
+                    ResponseEntry("500", PrivateBodyRequest::class, description = externalDesc)
+                ]
+            )
+            post("/postBodyRequestSimple") {
+                call.receive<SimpleRequest>()
+            }
+            @KtorResponds(
+                mapping = [
+                    ResponseEntry(
+                        "200", SimpleRequest::class, isCollection=true, "line0"
+                                + "line1"
+                                + "line3"
+                    )
+                ]
+            )
+            post("/implicitField") {
+                call.receive<SimpleRequest>()
+            }
+
+            @KtorResponds([ResponseEntry("200", SimpleRequest::class, isCollection=true)])
+            get("/implicitArgs") {
+
+            }
+        }
+    }
+}

--- a/create-plugin/src/test/resources/sources/Tags.kt
+++ b/create-plugin/src/test/resources/sources/Tags.kt
@@ -1,10 +1,12 @@
 package sources
 
+import io.github.tabilzad.ktor.Tag
 import io.ktor.server.application.*
 import io.ktor.server.routing.*
 import sources.annotations.KtorDocs
 
-@KtorDocs(["AppLevel"])
+@KtorDocs
+@Tag(["AppLevel"])
 fun Application.tagsAreAppliedToApplicationModule() {
     routing {
         route("/v1") {
@@ -15,7 +17,8 @@ fun Application.tagsAreAppliedToApplicationModule() {
     }
 }
 
-@KtorDocs(["RouteLevel"])
+@KtorDocs
+@Tag(["RouteLevel"])
 fun Route.tagsAreAppliedToRoute() {
     route("/v2") {
         get("/getRequest2") {

--- a/create-plugin/src/test/resources/sources/Tags2.kt
+++ b/create-plugin/src/test/resources/sources/Tags2.kt
@@ -1,0 +1,33 @@
+package sources
+
+import io.github.tabilzad.ktor.Tag
+import io.github.tabilzad.ktor.GenerateOpenApi
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
+
+
+@GenerateOpenApi
+@Tag(["Module"])
+fun Application.module1() {
+    routing {
+        subModule1()
+        subModule2()
+    }
+}
+
+fun Route.subModule1() {
+    route("/submodule1") {
+        get("/sub1") {
+
+        }
+    }
+}
+
+@Tag(["SubModule"])
+fun Route.subModule2() {
+    route("/submodule2") {
+        get("/sub2") {
+
+        }
+    }
+}

--- a/create-plugin/src/test/resources/sources/Tags3.kt
+++ b/create-plugin/src/test/resources/sources/Tags3.kt
@@ -1,0 +1,30 @@
+package sources
+
+import io.github.tabilzad.ktor.Tag
+import io.github.tabilzad.ktor.KtorDocs
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
+
+@KtorDocs
+@Tag(["MainModule"])
+fun Application.module2() {
+    routing {
+        route("/l1") {
+            subModule1()
+            route("/l2") {
+                get("/l2get") {
+
+                }
+            }
+        }
+    }
+}
+
+@Tag(["SubModule"])
+fun Route.subModule1() {
+    route("/sub_l1") {
+        get("/sub_l1_get") {
+
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=io.github.tabilzad
-VERSION_NAME=0.5.4-alpha
+VERSION_NAME=0.6.0-alpha
 
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,9 @@
 [versions]
-jvmTarget = "11"
-kotlinVersion = "1.9.22"
-arrowVersion = "1.6.2"
+kotlinVersion = "2.0.0"
+classgraph = "4.8.157"
 jacksonVersion = "2.15.2"
 ktorVersion = "2.2.4"
-compilerTestingVersion = "1.5.0"
+compilerTestingVersion = "0.5.0-alpha08"
 assertJVerison = "3.24.2"
 
 [plugins]
@@ -18,19 +17,18 @@ ktor = ["ktor", "ktorNetty"]
 kotlinGradle = ["kotlinGradleApi","kotlinGradle"]
 
 [libraries]
-arrowMeta = { module = "io.arrow-kt:arrow-meta", version.ref = "arrowVersion" }
 kotlinCompiler = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlinVersion" }
 assertJ = {module = "org.assertj:assertj-core", version.ref = "assertJVerison"}
+classGraph = {module="io.github.classgraph:classgraph", version.ref="classgraph"}
 junit = {module = "org.junit:junit-bom", version = "5.10.0"}
 junitJupiter = {module = "org.junit.jupiter:junit-jupiter"}
-compilerTest = {module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "compilerTestingVersion"}
+compilerTest = {module = "dev.zacsweers.kctfork:core", version.ref = "compilerTestingVersion"}
 jacksonKotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jacksonVersion" }
 jacksonYaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jacksonVersion" }
 ktor = { module = "io.ktor:ktor", version.ref = "ktorVersion" }
 ktorNetty = { module = "io.ktor:ktor-server-netty", version.ref = "ktorVersion" }
 kotlinGradleApi = {module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlinVersion"}
 kotlinGradle = {module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinVersion"}
-arrowTest = { module = "io.arrow-kt:arrow-meta-test", version.ref = "arrowVersion" }
 kotlinReflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlinVersion" }
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Add support for Kotlin 2.0 (K2)
* K1 compiler will not be receiving new feature updates or bug fixes. 

### New features (K2 only)
* Derive field requirement from its type nullability
* Add support for sealed classes
* Add support for schema references with generic types
* @KtorDocs->@GenerateOpenApi
* Move annotations to `io.github.tabilzad.ktor.annotations` (will be published as a separate artifact)
* Amend @KtorDescription target to functions and expressions only
* Add @KtorFieldDescription with RUNTIME retention to support schemas defined in external modules.
* Remove arrow-meta