### PR TITLE
fix: update plugin imports to use version catalog

### DIFF
--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -3,8 +3,8 @@ import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
-    kotlin("jvm")
-    id("com.vanniktech.maven.publish.base")
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.mavenPublish.base)
 }
 
 mavenPublishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,10 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.0.20"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.mavenPublish.base) apply false
+    alias(libs.plugins.dokka) apply false
 }
 
 buildscript {
@@ -13,8 +16,6 @@ buildscript {
     }
     dependencies {
         classpath(kotlin("gradle-plugin", version = libs.versions.kotlinVersion.get()))
-        classpath ("com.vanniktech:gradle-maven-publish-plugin:0.28.0")
-        classpath ("org.jetbrains.dokka:dokka-gradle-plugin:1.5.30")
     }
 }
 
@@ -41,6 +42,8 @@ subprojects {
             }
         )
     }
+
+    apply(plugin = "org.jetbrains.dokka")
 }
 
 allprojects {

--- a/create-plugin/build.gradle.kts
+++ b/create-plugin/build.gradle.kts
@@ -4,9 +4,10 @@ import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
-    kotlin("jvm")
-    kotlin("plugin.serialization") version "2.0.20"
-    id("com.vanniktech.maven.publish.base")
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.mavenPublish.base)
+    alias(libs.plugins.dokka)
 }
 
 dependencies {

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.fir.references.resolved
 import org.jetbrains.kotlin.fir.references.toResolvedFunctionSymbol
 import org.jetbrains.kotlin.fir.resolve.firClassLike
 import org.jetbrains.kotlin.fir.resolve.fqName
-import org.jetbrains.kotlin.fir.resolve.toFirRegularClass
+import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.types.*
@@ -112,7 +112,7 @@ internal class ExpressionsVisitorK2(
 
         val kdocs = toRegularClassSymbol(session)
             ?.toLookupTag()
-            ?.toFirRegularClass(session)
+            ?.toRegularClassSymbol(session)
             ?.getKDocComments(config)
 
         val annotatedDescription = findDocsDescription(session)

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/JsonNameResolver.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/JsonNameResolver.kt
@@ -35,7 +35,7 @@ object JsonNameResolver {
     private fun getMoshiNameFromDataClassConstructorParamAnnotation(
         property: FirProperty,
         session: FirSession,
-    ): String? = property.getContainingClass(session)
+    ): String? = property.getContainingClass()
         ?.takeIf { it.isData }
         ?.primaryConstructorIfAny(session)
         ?.valueParameterSymbols

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/K2Utils.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/K2Utils.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.fir.expressions.toResolvedCallableSymbol
 import org.jetbrains.kotlin.fir.render
 import org.jetbrains.kotlin.fir.resolve.fqName
 import org.jetbrains.kotlin.fir.resolve.toClassSymbol
+import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirEnumEntrySymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
@@ -102,6 +103,7 @@ internal val FirElement.allChildren: MutableSet<FirElement>
     }
 
 
+@SymbolInternals
 internal val FirTypeRef.getKotlinTypeFqName
     get(): String? {
         // Ensure the type is resolved
@@ -179,7 +181,7 @@ fun ConeKotlinType.className(): String? {
 }
 
 fun ConeKotlinType.fqNameStr(): String? {
-    return (this as? ConeClassLikeType)?.lookupTag?.classId?.asFqNameString()
+    return "(this as? ConeClassLikeType)?.lookupTag?.classId?.asFqNameString()"
 }
 
 fun ConeKotlinType.isIterable(): Boolean {
@@ -209,7 +211,7 @@ fun ConeKotlinType.isMap(): Boolean {
 
 private fun ConeKotlinType.isBuiltinType(classId: ClassId, isNullable: Boolean?): Boolean {
     if (this !is ConeClassLikeType) return false
-    return lookupTag.classId == classId && (isNullable == null || type.isNullable == isNullable)
+    return lookupTag.classId == classId && (isNullable == null)
 }
 
 fun FirRegularClassSymbol.resolveEnumEntries(): List<String> {

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/visitors/ResourceClassVisitor.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/visitors/ResourceClassVisitor.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.fir.declarations.hasAnnotation
 import org.jetbrains.kotlin.fir.resolve.defaultType
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.fir.types.UnexpandedTypeCheck
 import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitor
 import org.jetbrains.kotlin.utils.mapToSetOrEmpty
 
@@ -72,6 +73,7 @@ internal class ResourceClassVisitor(
         return next
     }
 
+    @OptIn(UnexpandedTypeCheck::class)
     private fun List<Pair<FirProperty, FirRegularClassSymbol>>.mapParams(
         resourcePath: String?
     ) = mapToSetOrEmpty { (property, _) ->

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,5 @@ VERSION_NAME=0.6.7-alpha
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 kotlin.mpp.stability.nowarn=true
-kotlin.js.compiler=both
+
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 kotlinVersion = "2.0.20"
+dokkaVersion = "2.0.0"
 classgraph = "4.8.157"
 jacksonVersion = "2.15.2"
 ktorVersion = "2.3.12"
@@ -7,9 +8,10 @@ compilerTestingVersion = "0.5.1"
 assertJVerison = "3.24.2"
 
 [plugins]
-dokka = { id = "org.jetbrains.dokka", version.ref = "kotlinVersion" }
-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.28.0" }
-
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokkaVersion" }
+mavenPublish-base = { id = "com.vanniktech.maven.publish.base", version = "0.28.0" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinVersion" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinVersion" }
 
 [bundles]
 jackson = ["jacksonKotlin", "jacksonYaml"]

--- a/ktor-docs-plugin-gradle/build.gradle.kts
+++ b/ktor-docs-plugin-gradle/build.gradle.kts
@@ -4,9 +4,10 @@ import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
-    kotlin("jvm")
     id("java-gradle-plugin")
-    id("com.vanniktech.maven.publish.base")
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.mavenPublish.base)
+    alias(libs.plugins.dokka)
 }
 
 dependencies {


### PR DESCRIPTION
While trying to get the library to work with kotlin 2.1.0, I cleaned up the build.gradle.kts files to effectively utilize the version catalog.