### PR TITLE
fix: update plugin imports to use version catalog

### DIFF
--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -3,8 +3,8 @@ import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
-    kotlin("jvm")
-    id("com.vanniktech.maven.publish.base")
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.mavenPublish.base)
 }
 
 mavenPublishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,10 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.1.0"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.mavenPublish.base) apply false
+    alias(libs.plugins.dokka) apply false
 }
 
 buildscript {
@@ -13,8 +16,6 @@ buildscript {
     }
     dependencies {
         classpath(kotlin("gradle-plugin", version = libs.versions.kotlinVersion.get()))
-        classpath ("com.vanniktech:gradle-maven-publish-plugin:0.28.0")
-        classpath ("org.jetbrains.dokka:dokka-gradle-plugin:1.5.30")
     }
 }
 
@@ -41,6 +42,8 @@ subprojects {
             }
         )
     }
+
+    apply(plugin = "org.jetbrains.dokka")
 }
 
 allprojects {

--- a/create-plugin/build.gradle.kts
+++ b/create-plugin/build.gradle.kts
@@ -4,9 +4,10 @@ import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
-    kotlin("jvm")
-    kotlin("plugin.serialization") version "2.1.0"
-    id("com.vanniktech.maven.publish.base")
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.mavenPublish.base)
+    alias(libs.plugins.dokka)
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=io.github.tabilzad
-VERSION_NAME=0.7.0-alpha
+VERSION_NAME=0.6.7-alpha
 
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 kotlin.mpp.stability.nowarn=true
-kotlin.js.compiler=both
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=io.github.tabilzad
-VERSION_NAME=0.6.7-alpha
+VERSION_NAME=0.7.0-alpha
 
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,17 @@
 [versions]
-kotlinVersion = "2.1.0"
+kotlinVersion = "2.0.20"
+dokkaVersion = "2.0.0"
 classgraph = "4.8.157"
 jacksonVersion = "2.15.2"
 ktorVersion = "2.3.12"
-compilerTestingVersion = "0.7.0"
+compilerTestingVersion = "0.5.1"
 assertJVerison = "3.24.2"
 
 [plugins]
-dokka = { id = "org.jetbrains.dokka", version.ref = "kotlinVersion" }
-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.28.0" }
-
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokkaVersion" }
+mavenPublish-base = { id = "com.vanniktech.maven.publish.base", version = "0.28.0" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinVersion" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinVersion" }
 
 [bundles]
 jackson = ["jacksonKotlin", "jacksonYaml"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-kotlinVersion = "2.0.20"
+kotlinVersion = "2.1.0"
 dokkaVersion = "2.0.0"
 classgraph = "4.8.157"
 jacksonVersion = "2.15.2"
 ktorVersion = "2.3.12"
-compilerTestingVersion = "0.5.1"
+compilerTestingVersion = "0.7.0"
 assertJVerison = "3.24.2"
 
 [plugins]

--- a/ktor-docs-plugin-gradle/build.gradle.kts
+++ b/ktor-docs-plugin-gradle/build.gradle.kts
@@ -4,9 +4,9 @@ import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.SonatypeHost
 
 plugins {
-    kotlin("jvm")
     id("java-gradle-plugin")
-    id("com.vanniktech.maven.publish.base")
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.mavenPublish.base)
 }
 
 dependencies {


### PR DESCRIPTION
While trying to get the library to work with kotlin 2.1.0, I cleaned up the build.gradle.kts files to effectively utilize the version catalog.