### PR TITLE
fix: fixing security config generation

### DIFF
--- a/ktor-docs-plugin-gradle/src/main/kotlin/io/github/tabilzad/ktor/KtorInspektorGradleConfig.kt
+++ b/ktor-docs-plugin-gradle/src/main/kotlin/io/github/tabilzad/ktor/KtorInspektorGradleConfig.kt
@@ -3,7 +3,7 @@ package io.github.tabilzad.ktor
 import io.github.tabilzad.ktor.config.Info
 import io.github.tabilzad.ktor.config.InfoConfigBuilder
 import io.github.tabilzad.ktor.config.Scheme
-import io.github.tabilzad.ktor.config.SecurityConfigBuilder
+import io.github.tabilzad.ktor.config.SecurityBuilder
 
 open class DocumentationOptions(
     var generateRequestSchemas: Boolean = true,
@@ -17,17 +17,13 @@ open class DocumentationOptions(
     private val securitySchemes: MutableMap<String, Scheme> = mutableMapOf()
     private var info = Info()
 
-    fun security(block: SecurityConfigBuilder.() -> Unit) {
-        val builder = SecurityConfigBuilder()
+    fun security(block: SecurityBuilder.() -> Unit) {
+        val builder = SecurityBuilder()
         builder.block()
         builder.build().let {
-            it.scopes.forEach { scope ->
-                securityConfig.add(mapOf(scope.toPair()))
-            }
+            securityConfig.addAll(it.scopes)
 
-            it.schemes.forEach { (schemeKey, scheme) ->
-                securitySchemes[schemeKey] = scheme
-            }
+            securitySchemes.putAll(it.schemes)
         }
     }
 


### PR DESCRIPTION
Small PR to update the way that global security requirements are taken in to closer match the OpenAPI [spec](https://swagger.io/docs/specification/v3_0/authentication/#describing-security):

>That is, security is an array of hashmaps, where each hashmap contains one or more named security schemes. Items in a hashmap are combined using logical AND, and array items are combined using logical OR. Security schemes combined via OR are alternatives – any one can be used in the given context. Security schemes combined via AND must be used simultaneously in the same request. Here, we can use either Basic authentication or an API key:

So now the security should be taken in via:

```
security {
    scopes {
        or {
            +"JWT"

            and {
                "OIDC" to listOf("scope1", "scope2")
                "OAuth" to listOf("scope1", "scope2")
            }
        }
    }
```