### PR TITLE
feat: add empty response body support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ fun Route.ordersRouting() {
 
 ### Responses
 Defining response schemas and their corresponding HTTP status codes are done via `@KtorResponds` annotation on an endpoint. 
+`Nothing` is treated specially and will result in empty response body.
 
 ```kotlin
 @GenerateOpenApi
@@ -154,6 +155,7 @@ fun Route.ordersRouting() {
         @KtorResponds(
                [
                    ResponseEntry("200", Order::class, description = "Created order"),
+                   ResponseEntry("204", Nothing::class),
                    ResponseEntry("400", ErrorResponseSample::class, description = "Invalid order payload")
                ]
         )

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/FileUtils.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/FileUtils.kt
@@ -25,6 +25,7 @@ internal fun OpenApiSpec.serializeAndWriteTo(configuration: PluginConfiguration)
         val sorted = new.copy(
             components = new.components.copy(
                 schemas = new.components.schemas.toSortedMap()
+                    .filter { (key, value) -> key != "kotlin.Nothing" }
                     .mapValues {
                         it.value.copy(properties = it.value.properties?.toSortedMap())
                     }

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
@@ -26,7 +26,6 @@ import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitor
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.util.PrivateForInline
-import kotlin.reflect.typeOf
 
 internal class ExpressionsVisitorK2(
     private val config: PluginConfiguration,

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitor
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.util.PrivateForInline
+import kotlin.reflect.typeOf
 
 internal class ExpressionsVisitorK2(
     private val config: PluginConfiguration,
@@ -268,38 +269,44 @@ internal class ExpressionsVisitorK2(
                                 type = kotlinType.toString().toSwaggerType()
                             )
                         } else {
-
                             val typeRef = response.type?.generateTypeAndVisitMemberDescriptors()
                             OpenApiSpec.SchemaType(
                                 `$ref` = "${typeRef?.contentBodyRef}"
                             )
                         }
                     if (!response.isCollection) {
-                        response.status to
+                        if (kotlinType?.isNothing ?: false) {
+                            response.status to OpenApiSpec.ResponseDetails(
+                                response.descr,
+                                null,
+                            )
+                        } else {
+                            response.status to
                                 OpenApiSpec.ResponseDetails(
-                                    response.descr ?: "",
+                                    response.descr,
                                     mapOf(
                                         ContentType.APPLICATION_JSON to mapOf(
                                             "schema" to schema
                                         )
                                     )
                                 )
+                        }
                     } else {
                         response.status to
-                                OpenApiSpec.ResponseDetails(
-                                    response.descr ?: "",
-                                    mapOf(
-                                        ContentType.APPLICATION_JSON to mapOf(
-                                            "schema" to OpenApiSpec.SchemaType(
-                                                type = "array",
-                                                items = OpenApiSpec.SchemaRef(
-                                                    type = schema.type,
-                                                    `$ref` = schema.`$ref`
-                                                )
+                            OpenApiSpec.ResponseDetails(
+                                response.descr,
+                                mapOf(
+                                    ContentType.APPLICATION_JSON to mapOf(
+                                        "schema" to OpenApiSpec.SchemaType(
+                                            type = "array",
+                                            items = OpenApiSpec.SchemaRef(
+                                                type = schema.type,
+                                                `$ref` = schema.`$ref`
                                             )
                                         )
                                     )
                                 )
+                            )
                     }
                 }
 

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/output/OpenApiSpec.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/output/OpenApiSpec.kt
@@ -85,7 +85,7 @@ data class OpenApiSpec(
 
     data class ResponseDetails(
         val description: String,
-        val content: BodyContent
+        val content: BodyContent?
     )
 
     data class OpenApiComponents(

--- a/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
+++ b/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
@@ -311,6 +311,19 @@ class K2StabilityTest {
     }
 
     @Test
+    fun `should correctly resolve Nothing class into empty response annotations`() {
+        val (source, expected) = loadSourceAndExpected("ResponseBodyEmpty")
+        generateCompilerTest(
+            testFile,
+            source,
+            PluginConfiguration.createDefault(hideTransients = false, hidePrivateFields = false)
+        )
+        val result = testFile.readText()
+        result.assertWith(expected)
+    }
+
+
+    @Test
     fun `should handle abstract or sealed schema definitions`() {
         val (source, expected) = loadSourceAndExpected("Abstractions")
         generateCompilerTest(testFile, source, PluginConfiguration.createDefault())

--- a/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
+++ b/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
@@ -322,7 +322,6 @@ class K2StabilityTest {
         result.assertWith(expected)
     }
 
-
     @Test
     fun `should handle abstract or sealed schema definitions`() {
         val (source, expected) = loadSourceAndExpected("Abstractions")

--- a/create-plugin/src/test/resources/expected/ResponseBodyEmpty-expected.json
+++ b/create-plugin/src/test/resources/expected/ResponseBodyEmpty-expected.json
@@ -1,0 +1,92 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "Open API Specification",
+    "description" : "test",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/v1/noResponseBody": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "500": {
+            "description": "Failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sources.requests.PrivateBodyRequest"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/sources.requests.SimpleRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/implicitArgNames": {
+      "post": {
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/sources.requests.SimpleRequest"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "sources.requests.PrivateBodyRequest" : {
+        "type" : "object",
+        "properties" : {
+          "invisible" : {
+            "type" : "string"
+          },
+          "transientFieldInvisible" : {
+            "type" : "integer"
+          },
+          "visible" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "visible", "invisible", "transientFieldInvisible" ]
+      },
+      "sources.requests.SimpleRequest" : {
+        "type" : "object",
+        "properties" : {
+          "float" : {
+            "type" : "number"
+          },
+          "integer" : {
+            "type" : "integer"
+          },
+          "string" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "string", "integer", "float" ]
+      }
+    }
+  }
+}

--- a/create-plugin/src/test/resources/expected/ResponseBodyEmpty-expected.json
+++ b/create-plugin/src/test/resources/expected/ResponseBodyEmpty-expected.json
@@ -6,48 +6,48 @@
     "version" : "1.0.0"
   },
   "paths" : {
-    "/v1/noResponseBody": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Success"
+    "/v1/noResponseBody" : {
+      "post" : {
+        "responses" : {
+          "200" : {
+            "description" : "Success"
           },
-          "500": {
-            "description": "Failure",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sources.requests.PrivateBodyRequest"
+          "500" : {
+            "description" : "Failure",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/sources.requests.PrivateBodyRequest"
                 }
               }
             }
           }
         },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/sources.requests.SimpleRequest"
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/sources.requests.SimpleRequest"
               }
             }
           }
         }
       }
     },
-    "/v1/implicitArgNames": {
-      "post": {
-        "responses": {
-          "204": {
-            "description": ""
+    "/v1/implicitArgNames" : {
+      "post" : {
+        "responses" : {
+          "204" : {
+            "description" : ""
           }
         },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/sources.requests.SimpleRequest"
+        "requestBody" : {
+          "required" : true,
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/sources.requests.SimpleRequest"
               }
             }
           }

--- a/create-plugin/src/test/resources/sources/ResponseBodyEmpty.kt
+++ b/create-plugin/src/test/resources/sources/ResponseBodyEmpty.kt
@@ -1,0 +1,34 @@
+package sources
+
+import io.github.tabilzad.ktor.annotations.GenerateOpenApi
+import io.github.tabilzad.ktor.annotations.KtorResponds
+import io.github.tabilzad.ktor.annotations.ResponseEntry
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import sources.requests.PrivateBodyRequest
+import sources.requests.SimpleRequest
+
+@GenerateOpenApi
+fun Application.responseBodySample() {
+    routing {
+        route("/v1") {
+            @KtorResponds(
+                mapping = [
+                    ResponseEntry("200", Nothing::class, description = "Success"),
+                    ResponseEntry("500", PrivateBodyRequest::class, description = "Failure")
+                ]
+            )
+            post("/noResponseBody") {
+                call.receive<SimpleRequest>()
+            }
+
+            @KtorResponds([ResponseEntry("204", Nothing::class)])
+            post("/implicitArgNames") {
+                call.receive<SimpleRequest>()
+            }
+        }
+    }
+}


### PR DESCRIPTION
When using the the `Nothing` type in a `@KtorResponds([ResponseEntry("204", Nothing::class)])` annotation a empty response body will be created in the openapi spec.

It looked pretty straight forward so i gave it a try ... it's kinda late so i might have overlooked some stuff :) 