### PR TITLE
fix: adding ResponseEntry.type = Boolean

### DIFF
--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k1/visitors/ClassDescriptorVisitor.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k1/visitors/ClassDescriptorVisitor.kt
@@ -362,6 +362,7 @@ fun String.toSwaggerType(): String {
         "float", "kotlin/float" -> "number"
         "long", "kotlin/long" -> "integer"
         "string", "kotlin/string" -> "string"
+        "boolean", "kotlin/boolean" -> "boolean"
         else -> type
     }
 }

--- a/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
+++ b/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
@@ -323,6 +323,18 @@ class K2StabilityTest {
     }
 
     @Test
+    fun `should correctly resolve Boolean class into boolean response annotations`() {
+        val (source, expected) = loadSourceAndExpected("ResponseBodyBoolean")
+        generateCompilerTest(
+            testFile,
+            source,
+            PluginConfiguration.createDefault(hideTransients = false, hidePrivateFields = false)
+        )
+        val result = testFile.readText()
+        result.assertWith(expected)
+    }
+
+    @Test
     fun `should handle abstract or sealed schema definitions`() {
         val (source, expected) = loadSourceAndExpected("Abstractions")
         generateCompilerTest(testFile, source, PluginConfiguration.createDefault())

--- a/create-plugin/src/test/resources/expected/ResponseBodyBoolean-expected.json
+++ b/create-plugin/src/test/resources/expected/ResponseBodyBoolean-expected.json
@@ -1,0 +1,29 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "Open API Specification",
+    "description" : "test",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/booleanResponseBody" : {
+      "post" : {
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : { }
+  }
+}

--- a/create-plugin/src/test/resources/sources/ResponseBodyBoolean.kt
+++ b/create-plugin/src/test/resources/sources/ResponseBodyBoolean.kt
@@ -1,0 +1,22 @@
+package sources
+
+import io.github.tabilzad.ktor.annotations.GenerateOpenApi
+import io.github.tabilzad.ktor.annotations.KtorResponds
+import io.github.tabilzad.ktor.annotations.ResponseEntry
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+@GenerateOpenApi
+fun Application.responseBodySample() {
+    routing {
+        @KtorResponds(
+            mapping = [
+                ResponseEntry("200", Boolean::class, description = "Success"),
+            ]
+        )
+        post("/booleanResponseBody") {
+            call.respond(true)
+        }
+    }
+}


### PR DESCRIPTION
I noticed that using this:

```
    @KtorResponds([
        ResponseEntry(status = "200", Boolean::class, description = "Result"),
    ])
```

Wasn't properly registering the `Boolean` response type, so I made a test and verified the behavior, then found the code that I needed to update in `ClassDescriptorVisitor`