### PR TITLE
feat: map kotlinx-datetime classes to date-time

### DIFF
--- a/create-plugin/build.gradle.kts
+++ b/create-plugin/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(libs.serialization)
     implementation(libs.serialization.json)
     implementation(libs.bundles.ktor)
+    implementation(libs.kotlinx.datetime)
 
     testImplementation(projects.common)
     testImplementation(libs.classGraph)
@@ -29,6 +30,7 @@ dependencies {
     testImplementation(libs.assertJ)
     testImplementation(platform(libs.junit))
     testImplementation(libs.junitJupiter)
+    testImplementation(libs.kotlinx.datetime)
 }
 
 tasks.test {

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
@@ -383,6 +383,12 @@ internal class ExpressionsVisitorK2(
                 OpenApiSpec.SchemaType(
                     type = kotlinType.toString().toSwaggerType()
                 )
+            } else if (kotlinType?.lookupTagIfAny?.name?.asString() == "Instant" ||
+                kotlinType?.lookupTagIfAny?.name?.asString() == "LocalDateTime") {
+                OpenApiSpec.SchemaType(
+                    type = "string",
+                    format = "date-time"
+                )
             } else {
                 val typeRef = response.type?.generateTypeAndVisitMemberDescriptors()
                 OpenApiSpec.SchemaType(

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/K2Utils.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/K2Utils.kt
@@ -208,7 +208,9 @@ private fun ConeKotlinType.isBuiltinType(classId: ClassId, isNullable: Boolean?)
 
 @Suppress("CyclomaticComplexMethod")
 fun isDatetime(fqClassName: String): Boolean {
-    return fqClassName == "kotlinx.datetime.Instant" || fqClassName == "kotlinx.datetime.LocalDateTime"
+    return fqClassName == "kotlinx.datetime.Instant" ||
+            fqClassName == "kotlinx.datetime.LocalDateTime" ||
+            fqClassName == "java.time.Instant"
 }
 
 fun FirRegularClassSymbol.resolveEnumEntries(): List<String> {

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/K2Utils.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/K2Utils.kt
@@ -206,7 +206,6 @@ private fun ConeKotlinType.isBuiltinType(classId: ClassId, isNullable: Boolean?)
     return lookupTag.classId == classId && (isNullable == null || isNullableAny == isNullable)
 }
 
-
 @Suppress("CyclomaticComplexMethod")
 fun isDatetime(fqClassName: String): Boolean {
     return fqClassName == "kotlinx.datetime.Instant" || fqClassName == "kotlinx.datetime.LocalDateTime"

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/K2Utils.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/K2Utils.kt
@@ -206,6 +206,12 @@ private fun ConeKotlinType.isBuiltinType(classId: ClassId, isNullable: Boolean?)
     return lookupTag.classId == classId && (isNullable == null || isNullableAny == isNullable)
 }
 
+
+@Suppress("CyclomaticComplexMethod")
+fun isDatetime(fqClassName: String): Boolean {
+    return fqClassName == "kotlinx.datetime.Instant" || fqClassName == "kotlinx.datetime.LocalDateTime"
+}
+
 fun FirRegularClassSymbol.resolveEnumEntries(): List<String> {
     return declarationSymbols.filterIsInstance<FirEnumEntrySymbol>().map { it.name.asString() }
 }

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/visitors/ClassDescriptorVisitorK2.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/visitors/ClassDescriptorVisitorK2.kt
@@ -91,7 +91,7 @@ internal class ClassDescriptorVisitorK2(
                 ObjectType(type = "string", enum = enumValues)
             }
 
-            fqClassName?.let { isDatetime(it) } == true-> {
+            fqClassName?.let { isDatetime(it) } == true -> {
                 ObjectType(type = "string", format = "date-time")
             }
 

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/visitors/ClassDescriptorVisitorK2.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/visitors/ClassDescriptorVisitorK2.kt
@@ -91,6 +91,10 @@ internal class ClassDescriptorVisitorK2(
                 ObjectType(type = "string", enum = enumValues)
             }
 
+            fqClassName?.let { isDatetime(it) } == true-> {
+                ObjectType(type = "string", format = "date-time")
+            }
+
             typeSymbol?.isSealed == true -> {
 
                 if (!classNames.names.contains(fqClassName)) {

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/output/OpenApiSpec.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/output/OpenApiSpec.kt
@@ -2,12 +2,10 @@ package io.github.tabilzad.ktor.output
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.sun.security.ntlm.Server
 import io.github.tabilzad.ktor.ContentType
 import io.github.tabilzad.ktor.OpenApiSpecParam
 import io.github.tabilzad.ktor.model.Info
 import io.github.tabilzad.ktor.model.SecurityScheme
-import java.nio.file.Path
 
 internal typealias ContentSchema = Map<String, OpenApiSpec.SchemaType>
 
@@ -78,6 +76,7 @@ data class OpenApiSpec(
 
     data class SchemaType(
         val type: String? = null,
+        val format: String? = null,
         val items: SchemaRef? = null,
         @Suppress("ConstructorParameterNaming")
         val `$ref`: String? = null,

--- a/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
+++ b/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
@@ -347,6 +347,18 @@ class K2StabilityTest {
     }
 
     @Test
+    fun `should correctly resolve kotlinx-datetime using instant class into date-time response annotations, simple response body`() {
+        val (source, expected) = loadSourceAndExpected("ResponseBodyKotlinxDatetimeInstant2")
+        generateCompilerTest(
+            testFile,
+            source,
+            PluginConfiguration.createDefault(hideTransients = false, hidePrivateFields = false)
+        )
+        val result = testFile.readText()
+        result.assertWith(expected)
+    }
+
+    @Test
     fun `should correctly resolve kotlinx-datetime using localdatetime class into date-time response annotations`() {
         val (source, expected) = loadSourceAndExpected("ResponseBodyKotlinxDatetimeLocalDateTime")
         generateCompilerTest(

--- a/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
+++ b/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
@@ -335,6 +335,30 @@ class K2StabilityTest {
     }
 
     @Test
+    fun `should correctly resolve kotlinx-datetime using instant class into date-time response annotations`() {
+        val (source, expected) = loadSourceAndExpected("ResponseBodyKotlinxDatetimeInstant")
+        generateCompilerTest(
+            testFile,
+            source,
+            PluginConfiguration.createDefault(hideTransients = false, hidePrivateFields = false)
+        )
+        val result = testFile.readText()
+        result.assertWith(expected)
+    }
+
+    @Test
+    fun `should correctly resolve kotlinx-datetime using localdatetime class into date-time response annotations`() {
+        val (source, expected) = loadSourceAndExpected("ResponseBodyKotlinxDatetimeLocalDateTime")
+        generateCompilerTest(
+            testFile,
+            source,
+            PluginConfiguration.createDefault(hideTransients = false, hidePrivateFields = false)
+        )
+        val result = testFile.readText()
+        result.assertWith(expected)
+    }
+
+    @Test
     fun `should handle abstract or sealed schema definitions`() {
         val (source, expected) = loadSourceAndExpected("Abstractions")
         generateCompilerTest(testFile, source, PluginConfiguration.createDefault())

--- a/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/TestUtils.kt
+++ b/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/TestUtils.kt
@@ -183,5 +183,6 @@ private val deps = arrayOf(
     "kotlinx-coroutines-core:1.10.1",
     "moshi:1.14.0",
     "kotlinx-serialization-core:2.1.0",
+    "kotlinx-datetime:0.4.0",
     "annotations:0.6.7-alpha"
 )

--- a/create-plugin/src/test/resources/expected/ResponseBodyKotlinxDatetimeInstant-expected.json
+++ b/create-plugin/src/test/resources/expected/ResponseBodyKotlinxDatetimeInstant-expected.json
@@ -1,0 +1,40 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "Open API Specification",
+    "description" : "test",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/temp" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/sources.Response"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "sources.Response" : {
+        "type" : "object",
+        "properties" : {
+          "message" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        },
+        "required" : [ "message" ]
+      }
+    }
+  }
+}

--- a/create-plugin/src/test/resources/expected/ResponseBodyKotlinxDatetimeInstant2-expected.json
+++ b/create-plugin/src/test/resources/expected/ResponseBodyKotlinxDatetimeInstant2-expected.json
@@ -1,0 +1,30 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "Open API Specification",
+    "description" : "test",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/temp" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string",
+                  "format" : "date-time"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : { }
+  }
+}

--- a/create-plugin/src/test/resources/expected/ResponseBodyKotlinxDatetimeLocalDateTime-expected.json
+++ b/create-plugin/src/test/resources/expected/ResponseBodyKotlinxDatetimeLocalDateTime-expected.json
@@ -1,0 +1,40 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "Open API Specification",
+    "description" : "test",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/temp" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/sources.Response"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "sources.Response" : {
+        "type" : "object",
+        "properties" : {
+          "message" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        },
+        "required" : [ "message" ]
+      }
+    }
+  }
+}

--- a/create-plugin/src/test/resources/sources/ResponseBodyKotlinxDatetimeInstant.kt
+++ b/create-plugin/src/test/resources/sources/ResponseBodyKotlinxDatetimeInstant.kt
@@ -1,0 +1,31 @@
+package sources
+
+import io.github.tabilzad.ktor.annotations.GenerateOpenApi
+import io.github.tabilzad.ktor.annotations.KtorResponds
+import io.github.tabilzad.ktor.annotations.ResponseEntry
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class Response(
+    val message: Instant = Clock.System.now()
+)
+
+@GenerateOpenApi
+fun Application.responseBodySample() {
+    routing {
+        @KtorResponds(
+            mapping = [
+                ResponseEntry("200", Response::class, description = "Success"),
+            ]
+        )
+        get("temp") {
+            call.respond(Response())
+        }
+    }
+}

--- a/create-plugin/src/test/resources/sources/ResponseBodyKotlinxDatetimeInstant2.kt
+++ b/create-plugin/src/test/resources/sources/ResponseBodyKotlinxDatetimeInstant2.kt
@@ -1,0 +1,26 @@
+package sources
+
+import io.github.tabilzad.ktor.annotations.GenerateOpenApi
+import io.github.tabilzad.ktor.annotations.KtorResponds
+import io.github.tabilzad.ktor.annotations.ResponseEntry
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+
+@GenerateOpenApi
+fun Application.responseBodySample() {
+    routing {
+        @KtorResponds(
+            mapping = [
+                ResponseEntry("200", kotlinx.datetime.Instant::class, description = "Success"),
+            ]
+        )
+        get("temp") {
+            call.respond(Clock.System.now())
+        }
+    }
+}

--- a/create-plugin/src/test/resources/sources/ResponseBodyKotlinxDatetimeLocalDateTime.kt
+++ b/create-plugin/src/test/resources/sources/ResponseBodyKotlinxDatetimeLocalDateTime.kt
@@ -1,0 +1,31 @@
+package sources
+
+import io.github.tabilzad.ktor.annotations.GenerateOpenApi
+import io.github.tabilzad.ktor.annotations.KtorResponds
+import io.github.tabilzad.ktor.annotations.ResponseEntry
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.toKotlinLocalDateTime
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class Response(
+    val message: LocalDateTime = java.time.LocalDateTime.now().toKotlinLocalDateTime()
+)
+
+@GenerateOpenApi
+fun Application.responseBodySample() {
+    routing {
+        @KtorResponds(
+            mapping = [
+                ResponseEntry("200", Response::class, description = "Success"),
+            ]
+        )
+        get("temp") {
+            call.respond(Response())
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,4 +43,4 @@ kotlinReflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = 
 moshi = { module = "com.squareup.moshi:moshi", version = "1.14.0" }
 serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
 serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
-
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.4.0" }

--- a/ktor-docs-plugin-gradle/build.gradle.kts
+++ b/ktor-docs-plugin-gradle/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     shadow(projects.common)
     implementation(libs.serialization.json)
     implementation(libs.serialization)
+    implementation(libs.kotlinx.datetime)
 }
 
 gradlePlugin {


### PR DESCRIPTION
This is to address what I brought up here: https://github.com/tabilzad/ktor-docs-plugin/issues/46

The only issue I foresee is with `LocalDateTime` as it doesn't include a timezone by default 🤷 

I've added tests that verify the generated output matches this:

```
{
  "openapi" : "3.1.0",
  "info" : {
    "title" : "Open API Specification",
    "description" : "test",
    "version" : "1.0.0"
  },
  "paths" : {
    "/temp" : {
      "get" : {
        "responses" : {
          "200" : {
            "description" : "Success",
            "content" : {
              "application/json" : {
                "schema" : {
                  "$ref" : "#/components/schemas/sources.Response"
                }
              }
            }
          }
        }
      }
    }
  },
  "components" : {
    "schemas" : {
      "sources.Response" : {
        "type" : "object",
        "properties" : {
          "message" : {
            "type" : "string",
            "format" : "date-time"
          }
        },
        "required" : [ "message" ]
      }
    }
  }
}
```

So that we don't include unnecessary kotlinx-datetime stuff in our openapi specs 😄 