### PR TITLE
Allow Gradle build caching to work in strict mode

### DIFF
--- a/ktor-docs-plugin-gradle/src/main/kotlin/io/github/tabilzad/ktor/KtorMetaPlugin.kt
+++ b/ktor-docs-plugin-gradle/src/main/kotlin/io/github/tabilzad/ktor/KtorMetaPlugin.kt
@@ -8,6 +8,8 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Copy
 import org.jetbrains.kotlin.gradle.plugin.*
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
 import org.jetbrains.kotlin.tooling.core.toKotlinVersion
 import java.io.File
@@ -118,11 +120,6 @@ class KtorMetaPlugin @Inject constructor(
             task.outputs.dir(canonicalOutputDir)
                 .withPropertyName("openApiSpec")
 
-            // Always force regeneration if output file doesn't exist
-            if (!canonicalOutputFile.exists()) {
-                task.outputs.upToDateWhen { false }
-            }
-
             // Register plugin configuration as inputs so config changes trigger regeneration.
             // This applies to all modes - changing swagger { } config should always regenerate.
             task.inputs.property("swagger.enabled", swaggerExtension.pluginOptions.enabled)
@@ -148,7 +145,11 @@ class KtorMetaPlugin @Inject constructor(
                     // STRICT MODE: Always regenerate on every compilation.
                     // Guarantees correctness but disables incremental compilation benefits.
                     // Recommended for CI/CD and release builds.
-                    task.outputs.upToDateWhen { false }
+                    if (task is KotlinCompile) {
+                        task.incremental = false
+                    } else {
+                        task.outputs.upToDateWhen { false }
+                    }
                 }
 
                 "safe" -> {


### PR DESCRIPTION
The directory for the canonical output is already in the outputs property so Gradle is tracking it. This means the explicit up-to-date check was unnecessary. 

Also, since `strict` mode actually just requires a full recompile, we should accomplish this explicitly by disabling incremental compilation on the project, instead of modify the Gradle output check. The advantage here is that if the inputs to the compile task didn't change (i.e. source code), we don't still force a full compilation. Now, instead, Gradle can restore the previously created output (including the open api file).  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined the documentation generation task regeneration logic for improved build efficiency.
  * Enhanced incremental Kotlin compilation support to reduce unnecessary rebuilds and improve build times.
  * Improved caching mechanisms for documentation output files.
  * Optimized task configuration behavior for better overall build performance in the Ktor documentation plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->