### PR TITLE
Don't generate openAPI files for test compilation

### DIFF
--- a/ktor-docs-plugin-gradle/src/main/kotlin/io/github/tabilzad/ktor/KtorMetaPlugin.kt
+++ b/ktor-docs-plugin-gradle/src/main/kotlin/io/github/tabilzad/ktor/KtorMetaPlugin.kt
@@ -33,9 +33,15 @@ class KtorMetaPlugin @Inject constructor(
             version = inspektorVersion
         )
 
-    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>) = kotlinCompilation.target.project.run {
-        checkKotlinVersionCompatibility(this)
-        plugins.hasPlugin(KtorMetaPlugin::class.java)
+    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean {
+        val project = kotlinCompilation.target.project
+        checkKotlinVersionCompatibility(project)
+
+        val hasKtorMetaPlugin = project.plugins.hasPlugin(KtorMetaPlugin::class.java)
+        val isTestCompilation = kotlinCompilation.name.contains("test", ignoreCase = true)
+
+        // Skip test compilations — OpenAPI spec generation is only meaningful for main compilations
+        return hasKtorMetaPlugin && !isTestCompilation
     }
 
     override fun apply(target: Project) {


### PR DESCRIPTION
The plugin has always been doubly generating open API yaml files by applying the generation work to both the main and test compilation tasks. Given how the configuration works, it seems the intention was to not generate open API files in the test task so this turns it off. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin now correctly excludes test compilations from processing, preventing unnecessary operations on test source code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->