### PR TITLE
Fix implicit dependency issue

### DIFF
--- a/ktor-docs-plugin-gradle/src/main/kotlin/io/github/tabilzad/ktor/KtorMetaPlugin.kt
+++ b/ktor-docs-plugin-gradle/src/main/kotlin/io/github/tabilzad/ktor/KtorMetaPlugin.kt
@@ -91,6 +91,8 @@ class KtorMetaPlugin @Inject constructor(
 
             val copyTask = project.tasks.register(copyTaskName, Copy::class.java) { copy ->
                 copy.description = "Copies generated OpenAPI spec to configured destination"
+                // Declare an explicit task dependency so Gradle 8+ implicit-dependency validation is satisfied
+                copy.dependsOn(kotlinCompilation.compileTaskProvider)
                 copy.from(canonicalOutputFile)
                 copy.into(userDesiredFile.parentFile)
                 copy.rename { userDesiredFile.name }


### PR DESCRIPTION
There is a bug in the inspektor plugin — it writes the OpenAPI spec to build/openapi/ during the Kotlin compilation phase (via a compiler plugin), but the copyOpenApiSpec* tasks don't declare compileKotlin tasks as inputs. Gradle 8+ enforces implicit dependency validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved task execution order issues in the Ktor docs Gradle plugin, ensuring proper dependencies are enforced when building documentation with Gradle 8 and later versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->