### PR TITLE
Support custom response content types

### DIFF
--- a/annotations/src/main/kotlin/io/github/tabilzad/ktor/annotations/Annotations.kt
+++ b/annotations/src/main/kotlin/io/github/tabilzad/ktor/annotations/Annotations.kt
@@ -26,7 +26,8 @@ annotation class ResponseEntry(
     val status: String,
     val type: KClass<*>,
     val isCollection: Boolean = false,
-    val description: String = ""
+    val description: String = "",
+    val contentType: String = "application/json"
 )
 
 @Retention(AnnotationRetention.SOURCE)

--- a/annotations/src/main/kotlin/io/github/tabilzad/ktor/annotations/DescriptorsDsl.kt
+++ b/annotations/src/main/kotlin/io/github/tabilzad/ktor/annotations/DescriptorsDsl.kt
@@ -3,5 +3,10 @@ package io.github.tabilzad.ktor.annotations
 import io.ktor.http.*
 import io.ktor.server.routing.*
 
-inline fun <reified T> RoutingContext.responds(status: HttpStatusCode, description: String? = null): Unit = Unit
+inline fun <reified T> RoutingContext.responds(
+    status: HttpStatusCode,
+    description: String? = null,
+    contentType: String = "application/json"
+): Unit = Unit
+
 fun RoutingContext.respondsNothing(status: HttpStatusCode, description: String? = null): Unit = Unit

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/DataBag.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/DataBag.kt
@@ -1,6 +1,5 @@
 package io.github.tabilzad.ktor
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import io.github.tabilzad.ktor.output.OpenApiSpec
 
 interface OpenApiSpecParam {
@@ -87,10 +86,7 @@ data class RouteDescriptor(
     }
 }
 
-enum class ContentType {
-    @JsonProperty("application/json")
-    APPLICATION_JSON,
-
-    @JsonProperty("text/plain")
-    TEXT_PLAIN
+object ContentTypes {
+    const val APPLICATION_JSON = "application/json"
+    const val TEXT_PLAIN = "text/plain"
 }

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/Utils.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/Utils.kt
@@ -166,7 +166,7 @@ private fun addPostBody(it: KtorRouteSpec): OpenApiSpec.RequestBody? {
         OpenApiSpec.RequestBody(
             required = true,
             content = mapOf(
-                ContentType.APPLICATION_JSON to mapOf(
+                ContentTypes.APPLICATION_JSON to mapOf(
                     "schema" to OpenApiSpec.TypeDescriptor(
                         type = null,
                         ref = "${it.body.ref}"
@@ -178,7 +178,7 @@ private fun addPostBody(it: KtorRouteSpec): OpenApiSpec.RequestBody? {
         OpenApiSpec.RequestBody(
             required = true,
             content = mapOf(
-                ContentType.TEXT_PLAIN to mapOf(
+                ContentTypes.TEXT_PLAIN to mapOf(
                     "schema" to OpenApiSpec.TypeDescriptor(
                         type = "${it.body.type}",
                         description = it.body.description

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/ExpressionsVisitorK2.kt
@@ -115,20 +115,29 @@ internal class ExpressionsVisitorK2(
             (typeArguments.first() as FirTypeProjectionWithVariance).typeRef.coneType
         }
 
-        val code = ((arguments.first() as? FirPropertyAccessExpression)
+        val argByName = resolvedArgumentMapping?.entries
+            ?.associate { it.value.name.asString() to it.key }
+            .orEmpty()
+
+        val code = ((argByName["status"] as? FirPropertyAccessExpression)
             ?.calleeReference as? FirResolvedNamedReference)
             ?.name?.asString()
 
-        val descriptionExpression = arguments.lastOrNull()
-        val description = descriptionExpression
+        val description = (argByName["description"] as? FirLiteralExpression)
             ?.accept(StringResolutionVisitor(session), "")
             ?.ifBlank { null }
+
+        val contentType = (argByName["contentType"] as? FirLiteralExpression)
+            ?.accept(StringResolutionVisitor(session), "")
+            ?.ifBlank { null }
+            ?: "application/json"
 
         return KtorK2ResponseBag(
             descr = description ?: docs ?: "",
             status = HttpCodeResolver.resolve(code),
             type = type,
-            isCollection = false
+            isCollection = false,
+            contentType = contentType
         )
     }
 
@@ -369,24 +378,31 @@ internal class ExpressionsVisitorK2(
             if (kotlinType?.isNothing == true) {
                 response.status to OpenApiSpec.ResponseDetails(response.descr, null)
             } else {
-                val schema = response.type?.generateDescriptor()
                 response.status to OpenApiSpec.ResponseDetails(
                     response.descr,
                     mapOf(
-                        ContentType.APPLICATION_JSON to mapOf(
-                            "schema" to if (response.isCollection) {
-                                OpenApiSpec.TypeDescriptor(
-                                    type = "array",
-                                    items = OpenApiSpec.TypeDescriptor(type = null, ref = schema?.ref)
-                                )
-                            } else {
-                                schema ?: OpenApiSpec.TypeDescriptor("object")
-                            }
-                        )
+                        response.contentType to mapOf("schema" to response.toResponseSchema())
                     )
                 )
             }
         }
+
+    private fun KtorK2ResponseBag.toResponseSchema(): OpenApiSpec.TypeDescriptor {
+        val typeName = type?.classId?.shortClassName?.asString()
+        val isJsonLike = contentType == "application/json" || contentType.endsWith("+json")
+        if (!isJsonLike && typeName == "ByteArray") {
+            return OpenApiSpec.TypeDescriptor(type = "string", format = "binary")
+        }
+        val schema = type?.generateDescriptor()
+        return if (isCollection) {
+            OpenApiSpec.TypeDescriptor(
+                type = "array",
+                items = OpenApiSpec.TypeDescriptor(type = null, ref = schema?.ref)
+            )
+        } else {
+            schema ?: OpenApiSpec.TypeDescriptor("object")
+        }
+    }
 
     @OptIn(SymbolInternals::class)
     private fun FirFunctionCall.findResource(

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/visitors/RespondsAnnotationVisitor.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/k2/visitors/RespondsAnnotationVisitor.kt
@@ -13,7 +13,8 @@ internal data class KtorK2ResponseBag(
     val descr: String,
     val status: String,
     val type: ConeKotlinType?,
-    val isCollection: Boolean = false
+    val isCollection: Boolean = false,
+    val contentType: String = "application/json"
 )
 
 internal class RespondsAnnotationVisitor(private val session: FirSession) : FirDefaultVisitor<List<KtorK2ResponseBag>, KtorK2ResponseBag?>() {
@@ -30,13 +31,17 @@ internal class RespondsAnnotationVisitor(private val session: FirSession) : FirD
         val isCollection = functionCall.resolvedArgumentMapping?.findValueOfField("isCollection") as? FirLiteralExpression
         val description =
             functionCall.resolvedArgumentMapping?.findValueOfField("description") as? FirLiteralExpression
+        val contentType =
+            functionCall.resolvedArgumentMapping?.findValueOfField("contentType") as? FirLiteralExpression
 
         return listOf(
             KtorK2ResponseBag(
                 descr = description?.accept(StringResolutionVisitor(session), "") ?: "",
                 status = status?.accept(StringResolutionVisitor(session), "") ?: "UNKNOWN",
                 type = type?.resolvedType?.typeArguments?.firstOrNull()?.type,
-                isCollection = isCollection?.value as? Boolean ?: false
+                isCollection = isCollection?.value as? Boolean ?: false,
+                contentType = contentType?.accept(StringResolutionVisitor(session), "")
+                    ?.ifBlank { null } ?: "application/json"
             )
         )
     }

--- a/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/output/OpenApiSpec.kt
+++ b/create-plugin/src/main/kotlin/io/github/tabilzad/ktor/output/OpenApiSpec.kt
@@ -2,14 +2,13 @@ package io.github.tabilzad.ktor.output
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
-import io.github.tabilzad.ktor.ContentType
 import io.github.tabilzad.ktor.OpenApiSpecParam
 import io.github.tabilzad.ktor.model.Info
 import io.github.tabilzad.ktor.model.SecurityScheme
 
 internal typealias ContentSchema = Map<String, OpenApiSpec.TypeDescriptor>
 
-internal typealias BodyContent = Map<ContentType, ContentSchema>
+internal typealias BodyContent = Map<String, ContentSchema>
 
 data class OpenApiSpec(
     val openapi: String = "3.1.0",

--- a/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
+++ b/create-plugin/src/test/kotlin/io/github/tabilzad/ktor/K2StabilityTest.kt
@@ -586,6 +586,14 @@ class K2StabilityTest {
     }
 
     @Test
+    fun `should emit custom content type and binary schema for ByteArray responses`() {
+        val (source, expected) = loadSourceAndExpected("BinaryResponseContentType")
+        generateCompilerTest(testFile, source, PluginConfiguration.createDefault())
+        val result = testFile.readText()
+        result.assertWith(expected)
+    }
+
+    @Test
     fun `should resolve multiple responses with nested generics from inline responds endpoint extension`() {
         val (source, expected) = loadSourceAndExpected("MultipleRespondsTypes")
         generateCompilerTest(testFile, source, PluginConfiguration.createDefault())

--- a/create-plugin/src/test/resources/expected/BinaryResponseContentType-expected.json
+++ b/create-plugin/src/test/resources/expected/BinaryResponseContentType-expected.json
@@ -1,0 +1,64 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "Open API Specification",
+    "description" : "test",
+    "version" : "1.0.0"
+  },
+  "paths" : {
+    "/pdf" : {
+      "post" : {
+        "responses" : {
+          "200" : {
+            "description" : "PDF document",
+            "content" : {
+              "application/pdf" : {
+                "schema" : {
+                  "type" : "string",
+                  "format" : "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/png" : {
+      "post" : {
+        "responses" : {
+          "200" : {
+            "description" : "",
+            "content" : {
+              "image/png" : {
+                "schema" : {
+                  "type" : "string",
+                  "format" : "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pdfAnnotation" : {
+      "post" : {
+        "responses" : {
+          "200" : {
+            "description" : "PDF document",
+            "content" : {
+              "application/pdf" : {
+                "schema" : {
+                  "type" : "string",
+                  "format" : "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : { }
+  }
+}

--- a/create-plugin/src/test/resources/sources/BinaryResponseContentType.kt
+++ b/create-plugin/src/test/resources/sources/BinaryResponseContentType.kt
@@ -1,0 +1,38 @@
+package sources
+
+import io.github.tabilzad.ktor.annotations.GenerateOpenApi
+import io.github.tabilzad.ktor.annotations.KtorResponds
+import io.github.tabilzad.ktor.annotations.ResponseEntry
+import io.github.tabilzad.ktor.annotations.responds
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
+
+@GenerateOpenApi
+fun Application.binaryResponseContentType() {
+    routing {
+        // DSL: explicit application/pdf with ByteArray body → emits {type: string, format: binary}
+        post("/pdf") {
+            responds<ByteArray>(HttpStatusCode.OK, contentType = "application/pdf", description = "PDF document")
+        }
+
+        // DSL: explicit image/png with ByteArray body
+        post("/png") {
+            responds<ByteArray>(HttpStatusCode.OK, contentType = "image/png")
+        }
+
+        // Annotation form with contentType
+        @KtorResponds(
+            [
+                ResponseEntry(
+                    "200",
+                    ByteArray::class,
+                    description = "PDF document",
+                    contentType = "application/pdf"
+                ),
+            ]
+        )
+        post("/pdfAnnotation") {
+        }
+    }
+}


### PR DESCRIPTION
Closes #72

## What changed

- Adds a `contentType` parameter to the `responds` DSL and `ResponseEntry` annotation, defaulting to `"application/json"` — fully backwards compatible
- Replaces the internal 2-value `ContentType` enum with a plain `String` so any media type flows through the pipeline unchanged
- When a non-JSON `contentType` is paired with a `ByteArray` response, the emitted schema is `{ type: string, format: binary }` instead of an array

## Usage

DSL form:
```kotlin
post("/convert") {
    responds<ByteArray>(HttpStatusCode.OK, contentType = "application/pdf", description = "PDF document")
    respondsNothing(HttpStatusCode.BadRequest)
}
```

Annotation form:
```kotlin
@KtorResponds([
    ResponseEntry("200", ByteArray::class, contentType = "application/pdf", description = "PDF document"),
    ResponseEntry("400", Nothing::class)
])
post("/convert") { ... }
```

## Tests

Added `BinaryResponseContentType` fixture + test case in `K2StabilityTest` covering:
- DSL with `application/pdf` → `{type: string, format: binary}`
- DSL with `image/png` → same
- Annotation form with `application/pdf`

All existing tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API responses now support specifying custom content types for both DSL and annotation-based configurations
  * Improved OpenAPI schema generation for binary responses and custom media types (e.g., PDFs, images)

* **Tests**
  * Added test coverage for binary response content type handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tabilzad/inspektor/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->